### PR TITLE
Implement "Change Type" dialog for tasks in the behavior tree editor

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -323,6 +323,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 			rename_edit->grab_focus();
 		} break;
 		case ACTION_CHANGE_TYPE: {
+			change_type_palette->clear_filter();
 			change_type_palette->refresh();
 			Rect2 rect = Rect2(get_global_mouse_position(), Size2(400.0, 600.0) * EDSCALE);
 			change_type_popup->popup(rect);
@@ -1092,6 +1093,7 @@ LimboAIEditor::LimboAIEditor() {
 	add_child(change_type_popup);
 	change_type_palette = memnew(TaskPalette);
 	change_type_popup->add_child(change_type_palette);
+	change_type_palette->use_dialog_mode();
 	change_type_palette->connect("task_selected", callable_mp(this, &LimboAIEditor::_task_type_selected));
 
 	banners = memnew(VBoxContainer);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1091,10 +1091,22 @@ LimboAIEditor::LimboAIEditor() {
 
 	change_type_popup = memnew(PopupPanel);
 	add_child(change_type_popup);
-	change_type_palette = memnew(TaskPalette);
-	change_type_popup->add_child(change_type_palette);
-	change_type_palette->use_dialog_mode();
-	change_type_palette->connect("task_selected", callable_mp(this, &LimboAIEditor::_task_type_selected));
+	{
+		VBoxContainer *change_type_vbox = memnew(VBoxContainer);
+		change_type_popup->add_child(change_type_vbox);
+
+		Label *change_type_title = memnew(Label);
+		change_type_vbox->add_child(change_type_title);
+		change_type_title->set_theme_type_variation("HeaderSmall");
+		change_type_title->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+		change_type_title->set_text(TTR("Choose New Type"));
+
+		change_type_palette = memnew(TaskPalette);
+		change_type_vbox->add_child(change_type_palette);
+		change_type_palette->use_dialog_mode();
+		change_type_palette->connect("task_selected", callable_mp(this, &LimboAIEditor::_task_type_selected));
+		change_type_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+	}
 
 	banners = memnew(VBoxContainer);
 	vbox->add_child(banners);

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -31,6 +31,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/popup.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
@@ -42,6 +43,7 @@ class LimboAIEditor : public Control {
 private:
 	enum Action {
 		ACTION_RENAME,
+		ACTION_CHANGE_TYPE,
 		ACTION_EDIT_PROBABILITY,
 		ACTION_EDIT_SCRIPT,
 		ACTION_OPEN_DOC,
@@ -70,6 +72,7 @@ private:
 		Ref<Texture2D> percent_icon;
 		Ref<Texture2D> remove_task_icon;
 		Ref<Texture2D> rename_task_icon;
+		Ref<Texture2D> change_type_icon;
 	} theme_cache;
 
 	Vector<Ref<BehaviorTree>> history;
@@ -91,6 +94,9 @@ private:
 	Button *weight_mode;
 	Button *percent_mode;
 
+	PopupPanel *change_type_popup;
+	TaskPalette *change_type_palette;
+
 	FileDialog *save_dialog;
 	FileDialog *load_dialog;
 	Button *history_back;
@@ -110,7 +116,8 @@ private:
 	HashSet<String> disk_changed_files;
 
 	void _add_task(const Ref<BTTask> &p_task);
-	void _add_task_by_class_or_path(String p_class_or_path);
+	Ref<BTTask> _create_task_by_class_or_path(const String &p_class_or_path) const;
+	void _add_task_by_class_or_path(const String &p_class_or_path);
 	void _remove_task(const Ref<BTTask> &p_task);
 	_FORCE_INLINE_ void _add_task_with_prototype(const Ref<BTTask> &p_prototype) { _add_task(p_prototype->clone()); }
 	void _update_header() const;
@@ -145,6 +152,9 @@ private:
 	void _on_history_forward();
 	void _on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, int p_type);
 	void _on_resources_reload(const Vector<String> &p_resources);
+
+	void _task_type_selected(const String &p_class_or_path);
+	void _replace_task(const Ref<BTTask> &p_task, const Ref<BTTask> &p_by_task);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 

--- a/editor/task_palette.cpp
+++ b/editor/task_palette.cpp
@@ -179,6 +179,10 @@ void TaskPalette::_on_task_button_pressed(const String &p_task) {
 }
 
 void TaskPalette::_on_task_button_rmb(const String &p_task) {
+	if (dialog_mode) {
+		return;
+	}
+
 	ERR_FAIL_COND(p_task.is_empty());
 
 	context_task = p_task;
@@ -415,12 +419,18 @@ void TaskPalette::refresh() {
 		sec->connect(SNAME("task_button_pressed"), callable_mp(this, &TaskPalette::_on_task_button_pressed));
 		sec->connect(SNAME("task_button_rmb"), callable_mp(this, &TaskPalette::_on_task_button_rmb));
 		sections->add_child(sec);
-		sec->set_collapsed(collapsed_sections.has(cat));
+		sec->set_collapsed(!dialog_mode && collapsed_sections.has(cat));
 	}
 
-	if (!filter_edit->get_text().is_empty()) {
+	if (!dialog_mode && !filter_edit->get_text().is_empty()) {
 		_apply_filter(filter_edit->get_text());
 	}
+}
+
+void TaskPalette::use_dialog_mode() {
+	tool_filters->hide();
+	tool_refresh->hide();
+	dialog_mode = true;
 }
 
 void TaskPalette::_update_theme_item_cache() {

--- a/editor/task_palette.h
+++ b/editor/task_palette.h
@@ -118,6 +118,7 @@ private:
 	VBoxContainer *category_list;
 
 	String context_task;
+	bool dialog_mode = false;
 
 	void _menu_action_selected(int p_id);
 	void _on_task_button_pressed(const String &p_task);
@@ -149,6 +150,8 @@ protected:
 
 public:
 	void refresh();
+	void use_dialog_mode();
+	void clear_filter() { filter_edit->set_text(""); }
 
 	TaskPalette();
 	~TaskPalette();


### PR DESCRIPTION
This PR implements "Change Type" popup and menu action. Changing a type also copies some task properties, like a custom name and probability weight (when inside a ProbabilitySelector).

![change_type_popup](https://github.com/limbonaut/limboai/assets/2766569/9d54b61d-14dd-444a-a033-7b59bb423734)


Closes #3.