### PR TITLE
GHA: Double zip editor artifacts for MacOS and Linux (fix for #6).

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,6 +179,18 @@ jobs:
           mv bin/* ${{env.OUTDIR}}
           ls -R out/
 
+      # Zipping the editor artifact to retain executable bit;
+      # workaround for: https://github.com/actions/upload-artifact/issues/38
+      - name: Zip the editor artifact
+        if: matrix.target == 'editor'
+        shell: bash
+        run: |
+          pushd out/
+          zip -r godot-limboai.editor.linux.zip *
+          rm godot.*
+          echo -e "## Why another ZIP inside?\n\nWorkaround for: https://github.com/actions/upload-artifact/issues/38\n" > README.md
+          popd
+
       - name: Rename templates
         if: startsWith(matrix.target, 'template')
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -223,6 +223,8 @@ jobs:
           name: macos-editor
           path: bin/
 
+      # Zipping the editor bundle to retain executable bit;
+      # workaround for: https://github.com/actions/upload-artifact/issues/38
       - name: Make editor bundle
         run: |
           ls bin/
@@ -234,6 +236,11 @@ jobs:
           mkdir -p out/editor/Godot.app/Contents/MacOS
           cp bin/godot.macos.editor.universal out/editor/Godot.app/Contents/MacOS/Godot
           chmod +x out/editor/Godot.app/Contents/MacOS/Godot
+          pushd out/editor
+          zip -r Godot.app.zip Godot.app
+          rm -rf Godot.app
+          echo -e "## Why another ZIP inside?\n\nWorkaround for: https://github.com/actions/upload-artifact/issues/38\n" > README.md
+          popd
           ls out/editor/
 
       - name: Upload editor bundle


### PR DESCRIPTION
Workaround for https://github.com/actions/upload-artifact/issues/38.
