### PR TITLE
Fix wrong parameter reference in Blackboard documentation

### DIFF
--- a/doc_classes/Blackboard.xml
+++ b/doc_classes/Blackboard.xml
@@ -45,7 +45,7 @@
 			<return type="bool" />
 			<param index="0" name="p_name" type="String" />
 			<description>
-				Returns [code]true[/code] if the Blackboard contains the [param p_key] variable, including the parent scopes.
+				Returns [code]true[/code] if the Blackboard contains the [param p_name] variable, including the parent scopes.
 			</description>
 		</method>
 		<method name="prefetch_nodepath_vars">


### PR DESCRIPTION
Fixes the following error when running the upstream `pre-commit-make-rst` hook:
```
ERROR: Blackboard.xml: Unresolved argument reference "p_key" in method "has_var" description.
```