### PR TITLE
bugfix: make LimboState dispatch be recursive

### DIFF
--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -117,6 +117,9 @@ bool LimboState::dispatch(const String &p_event, const Variant &p_cargo) {
 			return ret;
 		}
 	}
+	else if (this->get_parent()->is_class("LimboState")) {
+		return static_cast<LimboState*>(this->get_parent())->dispatch(p_event, p_cargo);
+	}
 	return false;
 }
 


### PR DESCRIPTION
I fixed what I think is buggy behavior as stated in an issue I just posted.

By the way, I think the documentation for this method is misleading, since it does not specify that the called function should return a value.