### PR TITLE
Allow `LimboState::dispatch` to be called from inside the hierarchy.

### DIFF
--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -127,17 +127,17 @@ void LimboHSM::set_initial_state(LimboState *p_state) {
 	initial_state = Object::cast_to<LimboState>(p_state);
 }
 
-bool LimboHSM::dispatch(const String &p_event, const Variant &p_cargo) {
+bool LimboHSM::_dispatch(const String &p_event, const Variant &p_cargo) {
 	ERR_FAIL_COND_V(p_event.is_empty(), false);
 
 	bool event_consumed = false;
 
 	if (active_state) {
-		event_consumed = active_state->dispatch(p_event, p_cargo);
+		event_consumed = active_state->_dispatch(p_event, p_cargo);
 	}
 
 	if (!event_consumed) {
-		event_consumed = LimboState::dispatch(p_event, p_cargo);
+		event_consumed = LimboState::_dispatch(p_event, p_cargo);
 	}
 
 	if (!event_consumed && active_state) {

--- a/hsm/limbo_hsm.h
+++ b/hsm/limbo_hsm.h
@@ -43,6 +43,7 @@ protected:
 	void _notification(int p_what);
 
 	virtual void _initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard) override;
+	virtual bool _dispatch(const String &p_event, const Variant &p_cargo = Variant()) override;
 
 	virtual void _enter() override;
 	virtual void _exit() override;
@@ -62,7 +63,6 @@ public:
 	LimboState *get_initial_state() const { return initial_state; }
 
 	virtual void initialize(Node *p_agent, const Ref<Blackboard> &p_parent_scope = nullptr);
-	virtual bool dispatch(const String &p_event, const Variant &p_cargo = Variant()) override;
 
 	void update(double p_delta);
 	void add_transition(LimboState *p_from_state, LimboState *p_to_state, const String &p_event);

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -80,7 +80,7 @@ void LimboState::_initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard)
 	_setup();
 }
 
-bool LimboState::dispatch(const String &p_event, const Variant &p_cargo) {
+bool LimboState::_dispatch(const String &p_event, const Variant &p_cargo) {
 	ERR_FAIL_COND_V(p_event.is_empty(), false);
 	if (handlers.size() > 0 && handlers.has(p_event)) {
 		Variant ret;
@@ -124,6 +124,10 @@ void LimboState::add_event_handler(const String &p_event, const Callable &p_hand
 	ERR_FAIL_COND(p_event.is_empty());
 	ERR_FAIL_COND(!p_handler.is_valid());
 	handlers.insert(p_event, p_handler);
+}
+
+bool LimboState::dispatch(const String &p_event, const Variant &p_cargo) {
+	return get_root()->_dispatch(p_event, p_cargo);
 }
 
 LimboState *LimboState::call_on_enter(const Callable &p_callable) {

--- a/hsm/limbo_state.h
+++ b/hsm/limbo_state.h
@@ -54,6 +54,7 @@ protected:
 	void _notification(int p_what);
 
 	virtual void _initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard);
+	virtual bool _dispatch(const String &p_event, const Variant &p_cargo = Variant());
 
 	virtual void _setup();
 	virtual void _enter();
@@ -67,8 +68,6 @@ protected:
 	GDVIRTUAL1(_update, double);
 #endif // LIMBOAI_MODULE
 
-	void add_event_handler(const String &p_event, const Callable &p_handler);
-
 public:
 	void set_blackboard_plan(const Ref<BlackboardPlan> p_plan) { blackboard_plan = p_plan; }
 	Ref<BlackboardPlan> get_blackboard_plan() const { return blackboard_plan; }
@@ -78,12 +77,13 @@ public:
 	Node *get_agent() const { return agent; }
 	void set_agent(Node *p_agent) { agent = p_agent; }
 
-	virtual bool dispatch(const String &p_event, const Variant &p_cargo = Variant());
-
 	LimboState *named(String p_name);
 	LimboState *call_on_enter(const Callable &p_callable);
 	LimboState *call_on_exit(const Callable &p_callable);
 	LimboState *call_on_update(const Callable &p_callable);
+
+	void add_event_handler(const String &p_event, const Callable &p_handler);
+	bool dispatch(const String &p_event, const Variant &p_cargo = Variant());
 
 	_FORCE_INLINE_ String event_finished() const { return LW_NAME(EVENT_FINISHED); }
 	LimboState *get_root() const;


### PR DESCRIPTION
Improves usability and removes requirement to call this method on the root state (see #49).