### PR TITLE
Change some includes to use relative paths

### DIFF
--- a/editor/editor_property_bb_param.cpp
+++ b/editor/editor_property_bb_param.cpp
@@ -15,11 +15,11 @@
 
 #include "editor_property_bb_param.h"
 
-#include "modules/limboai/blackboard/bb_param/bb_param.h"
-#include "modules/limboai/blackboard/bb_param/bb_variant.h"
-#include "modules/limboai/editor/editor_property_variable_name.h"
-#include "modules/limboai/editor/mode_switch_button.h"
-#include "modules/limboai/util/limbo_string_names.h"
+#include "../blackboard/bb_param/bb_param.h"
+#include "../blackboard/bb_param/bb_variant.h"
+#include "editor_property_variable_name.h"
+#include "mode_switch_button.h"
+#include "../util/limbo_string_names.h"
 
 #include "core/error/error_macros.h"
 #include "core/io/marshalls.h"

--- a/editor/editor_property_bb_param.h
+++ b/editor/editor_property_bb_param.h
@@ -18,9 +18,9 @@
 
 #include "editor/editor_inspector.h"
 
-#include "modules/limboai/blackboard/bb_param/bb_param.h"
-#include "modules/limboai/blackboard/blackboard_plan.h"
-#include "modules/limboai/editor/mode_switch_button.h"
+#include "../blackboard/bb_param/bb_param.h"
+#include "../blackboard/blackboard_plan.h"
+#include "mode_switch_button.h"
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/margin_container.h"


### PR DESCRIPTION
The paths before assumed we were inside the Godot modules folder. This change enables building as an external module.