### PR TITLE
Provide the previous state in the state_changed signal

### DIFF
--- a/doc/source/classes/class_limbohsm.rst
+++ b/doc/source/classes/class_limbohsm.rst
@@ -52,6 +52,8 @@ Methods
    +-------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`LimboState<class_LimboState>` | :ref:`get_leaf_state<class_LimboHSM_method_get_leaf_state>` **(** **)** |const|                                                                                                        |
    +-------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+   | :ref:`LimboState<class_LimboState>` | :ref:`get_previous_active_state<class_LimboHSM_method_get_previous_active_state>` **(** **)** |const|                                                                                  |
+   +-------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | void                                | :ref:`initialize<class_LimboHSM_method_initialize>` **(** Node agent, :ref:`Blackboard<class_Blackboard>` parent_scope=null **)**                                                      |
    +-------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | void                                | :ref:`set_active<class_LimboHSM_method_set_active>` **(** bool active **)**                                                                                                            |
@@ -68,11 +70,11 @@ Methods
 Signals
 -------
 
-.. _class_LimboHSM_signal_state_changed:
+.. _class_LimboHSM_signal_active_state_changed:
 
 .. rst-class:: classref-signal
 
-**state_changed** **(** :ref:`LimboState<class_LimboState>` state **)**
+**active_state_changed** **(** :ref:`LimboState<class_LimboState>` current, :ref:`LimboState<class_LimboState>` previous **)**
 
 Emitted when the currently active substate is switched to a different substate.
 
@@ -210,6 +212,18 @@ Returns the currently active substate.
 :ref:`LimboState<class_LimboState>` **get_leaf_state** **(** **)** |const|
 
 Returns the currently active leaf state within the state machine.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_LimboHSM_method_get_previous_active_state:
+
+.. rst-class:: classref-method
+
+:ref:`LimboState<class_LimboState>` **get_previous_active_state** **(** **)** |const|
+
+Returns the previously active substate.
 
 .. rst-class:: classref-item-separator
 

--- a/doc_classes/LimboHSM.xml
+++ b/doc_classes/LimboHSM.xml
@@ -30,6 +30,12 @@
 				Returns the currently active leaf state within the state machine.
 			</description>
 		</method>
+		<method name="get_previous_active_state" qualifiers="const">
+			<return type="LimboState" />
+			<description>
+				Returns the previously active substate.
+			</description>
+		</method>
 		<method name="initialize">
 			<return type="void" />
 			<param index="0" name="agent" type="Node" />
@@ -65,8 +71,9 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="state_changed">
-			<param index="0" name="state" type="LimboState" />
+		<signal name="active_state_changed">
+			<param index="0" name="current" type="LimboState" />
+			<param index="1" name="previous" type="LimboState" />
 			<description>
 				Emitted when the currently active substate is switched to a different substate.
 			</description>

--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -61,12 +61,13 @@ void LimboHSM::_change_state(LimboState *p_state) {
 
 	if (active_state) {
 		active_state->_exit();
+		previous_active = active_state;
 	}
 
 	active_state = p_state;
 	active_state->_enter();
 
-	emit_signal(LimboStringNames::get_singleton()->state_changed, active_state);
+	emit_signal(LimboStringNames::get_singleton()->active_state_changed, active_state, previous_active);
 }
 
 void LimboHSM::_enter() {
@@ -247,6 +248,7 @@ void LimboHSM::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_initial_state"), &LimboHSM::get_initial_state);
 
 	ClassDB::bind_method(D_METHOD("get_active_state"), &LimboHSM::get_active_state);
+	ClassDB::bind_method(D_METHOD("get_previous_active_state"), &LimboHSM::get_previous_active_state);
 	ClassDB::bind_method(D_METHOD("get_leaf_state"), &LimboHSM::get_leaf_state);
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &LimboHSM::set_active);
 	ClassDB::bind_method(D_METHOD("update", "delta"), &LimboHSM::update);
@@ -263,11 +265,14 @@ void LimboHSM::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ANYSTATE", PROPERTY_HINT_RESOURCE_TYPE, "LimboState", 0), "", "anystate");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "initial_state", PROPERTY_HINT_RESOURCE_TYPE, "LimboState", 0), "set_initial_state", "get_initial_state");
 
-	ADD_SIGNAL(MethodInfo("state_changed", PropertyInfo(Variant::OBJECT, "state", PROPERTY_HINT_RESOURCE_TYPE, "LimboState", 0)));
+	ADD_SIGNAL(MethodInfo("active_state_changed",
+			PropertyInfo(Variant::OBJECT, "current", PROPERTY_HINT_RESOURCE_TYPE, "LimboState"),
+			PropertyInfo(Variant::OBJECT, "previous", PROPERTY_HINT_RESOURCE_TYPE, "LimboState")));
 }
 
 LimboHSM::LimboHSM() {
 	update_mode = UpdateMode::PHYSICS;
 	active_state = nullptr;
+	previous_active = nullptr;
 	initial_state = nullptr;
 }

--- a/hsm/limbo_hsm.h
+++ b/hsm/limbo_hsm.h
@@ -28,6 +28,7 @@ private:
 	UpdateMode update_mode;
 	LimboState *initial_state;
 	LimboState *active_state;
+	LimboState *previous_active;
 	HashMap<uint64_t, LimboState *> transitions;
 
 	_FORCE_INLINE_ uint64_t _get_transition_key(LimboState *p_from_state, const StringName &p_event) {
@@ -58,6 +59,7 @@ public:
 	UpdateMode get_update_mode() const { return update_mode; }
 
 	LimboState *get_active_state() const { return active_state; }
+	LimboState *get_previous_active_state() const { return previous_active; }
 	LimboState *get_leaf_state() const;
 	void set_active(bool p_active);
 

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -46,6 +46,7 @@ LimboStringNames::LimboStringNames() {
 	ActionCopy = SN("ActionCopy");
 	ActionCut = SN("ActionCut");
 	ActionPaste = SN("ActionPaste");
+	active_state_changed = SN("active_state_changed");
 	Add = SN("Add");
 	add_child = SN("add_child");
 	add_child_at_index = SN("add_child_at_index");
@@ -141,7 +142,6 @@ LimboStringNames::LimboStringNames() {
 	set_v_scroll = SN("set_v_scroll");
 	setup = SN("setup");
 	started = SN("started");
-	state_changed = SN("state_changed");
 	StatusWarning = SN("StatusWarning");
 	stopped = SN("stopped");
 	task_activated = SN("task_activated");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -60,6 +60,7 @@ public:
 	StringName ActionCopy;
 	StringName ActionCut;
 	StringName ActionPaste;
+	StringName active_state_changed;
 	StringName add_child_at_index;
 	StringName add_child;
 	StringName Add;
@@ -156,7 +157,6 @@ public:
 	StringName set_v_scroll;
 	StringName setup;
 	StringName started;
-	StringName state_changed;
 	StringName StatusWarning;
 	StringName stopped;
 	StringName task_activated;


### PR DESCRIPTION
- Also provide `get_previous_active_state()` method.
- Rename signal `state_changed` -> `active_state_changed`.

Resolves #59 