### PR TITLE
Set parent scope in state initialization

### DIFF
--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -197,11 +197,7 @@ void LimboHSM::initialize(Node *p_agent, const Ref<Blackboard> &p_parent_scope) 
 	ERR_FAIL_COND(p_agent == nullptr);
 	ERR_FAIL_COND_MSG(!is_root(), "LimboHSM: initialize() must be called on the root HSM.");
 
-	if (!p_parent_scope.is_null()) {
-		blackboard->set_parent(p_parent_scope);
-	}
-
-	_initialize(p_agent, nullptr);
+	_initialize(p_agent, p_parent_scope);
 
 	if (initial_state == nullptr) {
 		initial_state = Object::cast_to<LimboState>(get_child(0));


### PR DESCRIPTION
After the changes added in 2658060b1c634eacaf6c57592baf129746671f99, parent scope initialization is handled by `LimboState::_initialize`. Since HSM passes a `null` value, its parent scope ends up unset.