### PR TITLE
`BlackboardPlan` fixes

### DIFF
--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -121,7 +121,11 @@ bool BlackboardPlan::_property_get_revert(const StringName &p_name, Variant &r_p
 }
 
 void BlackboardPlan::set_base_plan(const Ref<BlackboardPlan> &p_base) {
-	base = p_base;
+	if (p_base == this) {
+		base.unref();
+	} else {
+		base = p_base;
+	}
 	sync_with_base_plan();
 	notify_property_list_changed();
 }

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -122,6 +122,7 @@ bool BlackboardPlan::_property_get_revert(const StringName &p_name, Variant &r_p
 
 void BlackboardPlan::set_base_plan(const Ref<BlackboardPlan> &p_base) {
 	if (p_base == this) {
+		WARN_PRINT_ED("BlackboardPlan: Using same resource for derived blackboard plan is not supported.");
 		base.unref();
 	} else {
 		base = p_base;

--- a/bt/behavior_tree.cpp
+++ b/bt/behavior_tree.cpp
@@ -48,7 +48,7 @@ void BehaviorTree::set_blackboard_plan(const Ref<BlackboardPlan> &p_plan) {
 		blackboard_plan->connect(LW_NAME(changed), callable_mp(this, &BehaviorTree::_plan_changed));
 	}
 
-	emit_changed();
+	_plan_changed();
 }
 
 void BehaviorTree::set_root_task(const Ref<BTTask> &p_value) {
@@ -79,6 +79,7 @@ Ref<BTTask> BehaviorTree::instantiate(Node *p_agent, const Ref<Blackboard> &p_bl
 }
 
 void BehaviorTree::_plan_changed() {
+	emit_signal(LW_NAME(plan_changed));
 	emit_changed();
 }
 
@@ -96,6 +97,8 @@ void BehaviorTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "description", PROPERTY_HINT_MULTILINE_TEXT), "set_description", "get_description");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT), "set_blackboard_plan", "get_blackboard_plan");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "root_task", PROPERTY_HINT_RESOURCE_TYPE, "BTTask", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_root_task", "get_root_task");
+
+	ADD_SIGNAL(MethodInfo("plan_changed"));
 }
 
 BehaviorTree::BehaviorTree() {

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -63,17 +63,21 @@ void BTPlayer::_load_tree() {
 void BTPlayer::_update_blackboard_plan() {
 	if (blackboard_plan.is_null()) {
 		blackboard_plan = Ref<BlackboardPlan>(memnew(BlackboardPlan));
+	} else if (!RESOURCE_IS_BUILT_IN(blackboard_plan)) {
+		WARN_PRINT_ED("BTPlayer: Using external resource for derived blackboard plan is not supported. Converted to built-in resource.");
+		blackboard_plan = blackboard_plan->duplicate();
 	}
+
 	blackboard_plan->set_base_plan(behavior_tree.is_valid() ? behavior_tree->get_blackboard_plan() : nullptr);
 }
 
 void BTPlayer::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 	if (Engine::get_singleton()->is_editor_hint()) {
-		if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(changed), callable_mp(this, &BTPlayer::_update_blackboard_plan))) {
-			behavior_tree->disconnect(LW_NAME(changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
+		if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(plan_changed), callable_mp(this, &BTPlayer::_update_blackboard_plan))) {
+			behavior_tree->disconnect(LW_NAME(plan_changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
 		}
 		if (p_tree.is_valid()) {
-			p_tree->connect(LW_NAME(changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
+			p_tree->connect(LW_NAME(plan_changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
 		}
 		behavior_tree = p_tree;
 		_update_blackboard_plan();
@@ -86,12 +90,7 @@ void BTPlayer::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 }
 
 void BTPlayer::set_blackboard_plan(const Ref<BlackboardPlan> &p_plan) {
-	if (p_plan.is_valid() && !RESOURCE_IS_BUILT_IN(p_plan)) {
-		WARN_PRINT_ED("BTPlayer: Using external resource for derived blackboard plan is not supported. Converted to built-in resource.");
-		blackboard_plan = p_plan->duplicate();
-	} else {
-		blackboard_plan = p_plan;
-	}
+	blackboard_plan = p_plan;
 	_update_blackboard_plan();
 }
 
@@ -217,8 +216,8 @@ void BTPlayer::_notification(int p_notification) {
 #endif // DEBUG_ENABLED
 
 			if (Engine::get_singleton()->is_editor_hint()) {
-				if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(changed), callable_mp(this, &BTPlayer::_update_blackboard_plan))) {
-					behavior_tree->disconnect(LW_NAME(changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
+				if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(plan_changed), callable_mp(this, &BTPlayer::_update_blackboard_plan))) {
+					behavior_tree->disconnect(LW_NAME(plan_changed), callable_mp(this, &BTPlayer::_update_blackboard_plan));
 				}
 			}
 

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -244,7 +244,7 @@ void BTPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Idle,Physics,Manual"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "get_active");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", 0), "set_blackboard", "get_blackboard");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT), "set_blackboard_plan", "get_blackboard_plan");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 
 	BIND_ENUM_CONSTANT(IDLE);
 	BIND_ENUM_CONSTANT(PHYSICS);

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -86,7 +86,12 @@ void BTPlayer::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 }
 
 void BTPlayer::set_blackboard_plan(const Ref<BlackboardPlan> &p_plan) {
-	blackboard_plan = p_plan;
+	if (p_plan.is_valid() && !RESOURCE_IS_BUILT_IN(p_plan)) {
+		WARN_PRINT_ED("BTPlayer: Using external resource for derived blackboard plan is not supported. Converted to built-in resource.");
+		blackboard_plan = p_plan->duplicate();
+	} else {
+		blackboard_plan = p_plan;
+	}
 	_update_blackboard_plan();
 }
 

--- a/bt/bt_state.cpp
+++ b/bt/bt_state.cpp
@@ -25,11 +25,11 @@
 
 void BTState::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 	if (Engine::get_singleton()->is_editor_hint()) {
-		if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan))) {
-			behavior_tree->disconnect(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan));
+		if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(plan_changed), callable_mp(this, &BTState::_update_blackboard_plan))) {
+			behavior_tree->disconnect(LW_NAME(plan_changed), callable_mp(this, &BTState::_update_blackboard_plan));
 		}
 		if (p_tree.is_valid()) {
-			p_tree->connect(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan));
+			p_tree->connect(LW_NAME(plan_changed), callable_mp(this, &BTState::_update_blackboard_plan));
 		}
 		behavior_tree = p_tree;
 		_update_blackboard_plan();
@@ -97,8 +97,8 @@ void BTState::_notification(int p_notification) {
 #endif // DEBUG_ENABLED
 
 			if (Engine::get_singleton()->is_editor_hint()) {
-				if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan))) {
-					behavior_tree->disconnect(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan));
+				if (behavior_tree.is_valid() && behavior_tree->is_connected(LW_NAME(plan_changed), callable_mp(this, &BTState::_update_blackboard_plan))) {
+					behavior_tree->disconnect(LW_NAME(plan_changed), callable_mp(this, &BTState::_update_blackboard_plan));
 				}
 			}
 		} break;

--- a/bt/bt_state.cpp
+++ b/bt/bt_state.cpp
@@ -31,16 +31,22 @@ void BTState::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 		if (p_tree.is_valid()) {
 			p_tree->connect(LW_NAME(changed), callable_mp(this, &BTState::_update_blackboard_plan));
 		}
+		behavior_tree = p_tree;
 		_update_blackboard_plan();
+	} else {
+		behavior_tree = p_tree;
 	}
-	behavior_tree = p_tree;
 }
 
 void BTState::_update_blackboard_plan() {
 	if (get_blackboard_plan().is_null()) {
-		set_blackboard_plan(Ref<BlackboardPlan>(memnew(BlackboardPlan)));
+		set_blackboard_plan(memnew(BlackboardPlan));
+	} else if (!RESOURCE_IS_BUILT_IN(get_blackboard_plan())) {
+		WARN_PRINT_ED("BTState: Using external resource for derived blackboard plan is not supported. Converted to built-in resource.");
+		set_blackboard_plan(get_blackboard_plan()->duplicate());
+	} else {
+		get_blackboard_plan()->set_base_plan(behavior_tree.is_valid() ? behavior_tree->get_blackboard_plan() : nullptr);
 	}
-	get_blackboard_plan()->set_base_plan(behavior_tree.is_valid() ? behavior_tree->get_blackboard_plan() : nullptr);
 }
 
 void BTState::_setup() {

--- a/doc/source/classes/class_behaviortree.rst
+++ b/doc/source/classes/class_behaviortree.rst
@@ -73,6 +73,23 @@ Methods
 
 .. rst-class:: classref-descriptions-group
 
+Signals
+-------
+
+.. _class_BehaviorTree_signal_plan_changed:
+
+.. rst-class:: classref-signal
+
+**plan_changed** **(** **)**
+
+Emitted when the :ref:`BlackboardPlan<class_BlackboardPlan>` changes.
+
+.. rst-class:: classref-section-separator
+
+----
+
+.. rst-class:: classref-descriptions-group
+
 Property Descriptions
 ---------------------
 

--- a/doc_classes/BehaviorTree.xml
+++ b/doc_classes/BehaviorTree.xml
@@ -58,4 +58,11 @@
 			User-provided description of the BehaviorTree.
 		</member>
 	</members>
+	<signals>
+		<signal name="plan_changed">
+			<description>
+				Emitted when the [BlackboardPlan] changes.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -206,7 +206,7 @@ void LimboState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "EVENT_FINISHED", PROPERTY_HINT_NONE, "", 0), "", "event_finished");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_agent", "get_agent");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", 0), "", "get_blackboard");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT), "set_blackboard_plan", "get_blackboard_plan");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 
 	ADD_SIGNAL(MethodInfo("setup"));
 	ADD_SIGNAL(MethodInfo("entered"));

--- a/hsm/limbo_state.h
+++ b/hsm/limbo_state.h
@@ -67,7 +67,7 @@ protected:
 
 public:
 	void set_blackboard_plan(const Ref<BlackboardPlan> &p_plan);
-	Ref<BlackboardPlan> get_blackboard_plan() const { return blackboard_plan; }
+	_FORCE_INLINE_ Ref<BlackboardPlan> get_blackboard_plan() const { return blackboard_plan; }
 
 	Ref<Blackboard> get_blackboard() const { return blackboard; }
 

--- a/util/limbo_compat.h
+++ b/util/limbo_compat.h
@@ -234,6 +234,7 @@ Variant VARIANT_DEFAULT(Variant::Type p_type);
 #define PROJECT_CONFIG_FILE() GET_PROJECT_SETTINGS_DIR().path_join("limbo_ai.cfg")
 #define IS_RESOURCE_FILE(m_path) (m_path.begins_with("res://") && m_path.find("::") == -1)
 #define RESOURCE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, m_type)
+#define RESOURCE_IS_BUILT_IN(m_res) (m_res->get_path().is_empty() || m_res->get_path().contains("::"))
 
 #ifdef TOOLS_ENABLED
 

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -122,6 +122,7 @@ LimboStringNames::LimboStringNames() {
 	NonFavorite = SN("NonFavorite");
 	normal = SN("normal");
 	panel = SN("panel");
+	plan_changed = SN("plan_changed");
 	popup_hide = SN("popup_hide");
 	pressed = SN("pressed");
 	probability_clicked = SN("probability_clicked");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -137,6 +137,7 @@ public:
 	StringName NonFavorite;
 	StringName normal;
 	StringName panel;
+	StringName plan_changed;
 	StringName popup_hide;
 	StringName pressed;
 	StringName probability_clicked;


### PR DESCRIPTION
* Avoid circular references in derived mode
* Always duplicate `BlackboardPlan` property resource for `BTPlayer` and `BTState`
* Prevent using external resources for derived blackboard plans