### PR TITLE
BTDecorator: Add default `_tick` implementation

### DIFF
--- a/bt/tasks/bt_decorator.cpp
+++ b/bt/tasks/bt_decorator.cpp
@@ -18,3 +18,8 @@ PackedStringArray BTDecorator::get_configuration_warnings() {
 	}
 	return warnings;
 }
+
+BT::Status BTDecorator::_tick(double p_delta) {
+	ERR_FAIL_COND_V_MSG(get_child_count() == 0, FAILURE, "BT decorator doesn't have a child.");
+	return get_child(0)->execute(p_delta);
+}

--- a/bt/tasks/bt_decorator.h
+++ b/bt/tasks/bt_decorator.h
@@ -17,6 +17,9 @@
 class BTDecorator : public BTTask {
 	GDCLASS(BTDecorator, BTTask)
 
+protected:
+	virtual Status _tick(double p_delta) override;
+
 public:
 	virtual PackedStringArray get_configuration_warnings() override;
 };


### PR DESCRIPTION
The default implementation simply ticks the child task and returns its status.