### PR TITLE
Fix GCC warning for unhandled 'PACKED_VECTOR4_ARRAY' in switch

### DIFF
--- a/util/limbo_utility.cpp
+++ b/util/limbo_utility.cpp
@@ -515,6 +515,7 @@ PackedInt32Array LimboUtility::get_property_hints_allowed_for_type(Variant::Type
 		case Variant::Type::PACKED_STRING_ARRAY:
 		case Variant::Type::PACKED_VECTOR2_ARRAY:
 		case Variant::Type::PACKED_VECTOR3_ARRAY:
+		case Variant::Type::PACKED_VECTOR4_ARRAY:
 		case Variant::Type::PACKED_COLOR_ARRAY:
 		case Variant::Type::VARIANT_MAX: {
 		} break;


### PR DESCRIPTION
Fixes the following warning:

```
[ 34%] modules/limboai/util/limbo_utility.cpp: In member function 'PackedInt32Array LimboUtility::get_property_hints_allowed_for_type(Variant::Type) const':
modules/limboai/util/limbo_utility.cpp:426:16: warning: enumeration value 'PACKED_VECTOR4_ARRAY' not handled in switch [-Wswitch]
  426 |         switch (p_type) {
      |                ^
```