### PR TITLE
Show version info in the editor

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -7,6 +7,9 @@ module_env = env.Clone()
 
 module_env.Append(CPPDEFINES=["LIMBOAI_MODULE"])
 
+import limboai_version
+limboai_version.generate_module_version_header()
+
 module_env.add_source_files(env.modules_sources, "*.cpp")
 module_env.add_source_files(env.modules_sources, "blackboard/*.cpp")
 module_env.add_source_files(env.modules_sources, "blackboard/bb_param/*.cpp")

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -20,6 +20,7 @@
 #include "../bt/tasks/decorators/bt_subtree.h"
 #include "../util/limbo_compat.h"
 #include "../util/limbo_utility.h"
+#include "../util/limboai_version.h"
 #include "action_banner.h"
 #include "blackboard_plan_editor.h"
 #include "debugger/limbo_debugger_plugin.h"
@@ -895,6 +896,10 @@ void LimboAIEditor::_task_type_selected(const String &p_class_or_path) {
 	_mark_as_dirty(true);
 }
 
+void LimboAIEditor::_copy_version_info() {
+	DisplayServer::get_singleton()->clipboard_set(version_btn->get_text());
+}
+
 void LimboAIEditor::_replace_task(const Ref<BTTask> &p_task, const Ref<BTTask> &p_by_task) {
 	ERR_FAIL_COND(p_task.is_null());
 	ERR_FAIL_COND(p_by_task.is_null());
@@ -1321,6 +1326,7 @@ void LimboAIEditor::_notification(int p_what) {
 			tab_bar->connect(LW_NAME(gui_input), callable_mp(this, &LimboAIEditor::_tab_input));
 			tab_menu->connect(LW_NAME(id_pressed), callable_mp(this, &LimboAIEditor::_tab_menu_option_selected));
 			tab_bar->connect("tab_button_pressed", callable_mp(this, &LimboAIEditor::_tab_plan_edited));
+			version_btn->connect(LW_NAME(pressed), callable_mp(this, &LimboAIEditor::_copy_version_info));
 
 			EDITOR_FILE_SYSTEM()->connect("resources_reload", callable_mp(this, &LimboAIEditor::_on_resources_reload));
 
@@ -1459,9 +1465,26 @@ LimboAIEditor::LimboAIEditor() {
 	misc_btn->set_flat(true);
 	toolbar->add_child(misc_btn);
 
-	HBoxContainer *nav = memnew(HBoxContainer);
-	nav->set_h_size_flags(SIZE_EXPAND | SIZE_SHRINK_END);
-	toolbar->add_child(nav);
+	HBoxContainer *toolbar_end_hbox = memnew(HBoxContainer);
+	toolbar_end_hbox->set_h_size_flags(SIZE_EXPAND | SIZE_SHRINK_END);
+	toolbar->add_child(toolbar_end_hbox);
+
+	TextureRect *logo = memnew(TextureRect);
+	logo->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+	logo->set_texture(LimboUtility::get_singleton()->get_task_icon("LimboAI"));
+	toolbar_end_hbox->add_child(logo);
+
+	version_btn = memnew(LinkButton);
+	version_btn->set_text(TTR("v") + String(GET_LIMBOAI_FULL_VERSION()));
+	version_btn->set_tooltip_text(TTR("Click to copy."));
+	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_v_size_flags(SIZE_SHRINK_CENTER);
+	toolbar_end_hbox->add_child(version_btn);
+
+	Control *version_spacer = memnew(Control);
+	version_spacer->set_custom_minimum_size(Size2(2, 0) * EDSCALE);
+	toolbar_end_hbox->add_child(version_spacer);
 
 	tab_bar_panel = memnew(PanelContainer);
 	vbox->add_child(tab_bar_panel);

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -34,6 +34,7 @@
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
@@ -55,6 +56,7 @@
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/h_split_container.hpp>
 #include <godot_cpp/classes/input_event.hpp>
+#include <godot_cpp/classes/link_button.hpp>
 #include <godot_cpp/classes/menu_button.hpp>
 #include <godot_cpp/classes/panel.hpp>
 #include <godot_cpp/classes/popup_menu.hpp>
@@ -139,6 +141,7 @@ private:
 	VBoxContainer *vbox;
 	PanelContainer *tab_bar_panel;
 	HBoxContainer *tab_bar_container;
+	LinkButton *version_btn;
 	TabBar *tab_bar;
 	PopupMenu *tab_menu;
 	OwnerPicker *owner_picker;
@@ -225,6 +228,7 @@ private:
 	void _on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, int p_type);
 	void _on_resources_reload(const PackedStringArray &p_resources);
 	void _task_type_selected(const String &p_class_or_path);
+	void _copy_version_info();
 
 	void _edit_project_settings();
 	void _process_shortcut_input(const Ref<InputEvent> &p_event);

--- a/gdextension/SConstruct
+++ b/gdextension/SConstruct
@@ -12,7 +12,15 @@ env = SConscript("godot-cpp/SConstruct")
 # - CPPDEFINES are for pre-processor defines
 # - LINKFLAGS are for linking flags
 
-# tweak this if you want to use different folders, or more folders, to store your source code in.
+# Generate version header.
+sys.path.append("./limboai")
+import limboai_version
+os.chdir("./limboai")
+limboai_version.generate_module_version_header()
+os.chdir("..")
+sys.path.remove("./limboai")
+
+# Tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=["limboai/"])
 env.Append(CPPDEFINES=["LIMBOAI_GDEXTENSION"])
 sources = Glob("limboai/*.cpp")

--- a/limboai_version.py
+++ b/limboai_version.py
@@ -1,0 +1,59 @@
+# Edit the following variables to change version info
+
+major = 1
+minor = 1
+patch = 0
+status = "dev"
+doc_branch = "latest"
+
+# Code that generates version header
+
+def _git_hash(short: bool = False):
+    import subprocess
+    ret = "unknown"
+    try:
+        if short:
+            cmd = ["git", "rev-parse", "--short", "HEAD"]
+        else:
+            cmd = ["git", "rev-parse", "HEAD"]
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        ret = proc.communicate()[0].strip().decode("utf-8")
+    except:
+        pass
+    return ret
+
+
+def _get_version_info():
+    return {
+        "major": major,
+        "minor": minor,
+        "patch": patch,
+        "status": status,
+        "doc_branch": doc_branch,
+        "git_short_hash": _git_hash(short=True),
+        "git_hash": _git_hash(short=False)
+    }
+
+
+def generate_module_version_header():
+    version_info = _get_version_info()
+    f = open("util/limboai_version.gen.h", "w")
+    f.write(
+        """/* THIS FILE IS GENERATED DO NOT EDIT */
+#ifndef LIMBOAI_VERSION_GEN_H
+#define LIMBOAI_VERSION_GEN_H
+
+#define LIMBOAI_VERSION_MAJOR {major}
+#define LIMBOAI_VERSION_MINOR {minor}
+#define LIMBOAI_VERSION_PATCH {patch}
+#define LIMBOAI_VERSION_STATUS "{status}"
+
+#define LIMBOAI_VERSION_HASH "{git_hash}"
+#define LIMBOAI_VERSION_SHORT_HASH "{git_short_hash}"
+
+#define LIMBOAI_VERSION_DOC_BRANCH "{doc_branch}"
+#define LIMBOAI_VERSION_DOC_URL "https://limboai.readthedocs.io/en/" LIMBOAI_VERSION_DOC_BRANCH "/"
+
+#endif // LIMBOAI_VERSION_GEN_H
+""".format(**version_info))
+    f.close()

--- a/util/limbo_utility.cpp
+++ b/util/limbo_utility.cpp
@@ -13,6 +13,7 @@
 
 #include "../bt/tasks/bt_task.h"
 #include "../util/limbo_compat.h"
+#include "limboai_version.h"
 
 #ifdef LIMBOAI_MODULE
 #include "core/config/project_settings.h"
@@ -568,23 +569,19 @@ Ref<Shortcut> LimboUtility::get_shortcut(const String &p_path) const {
 }
 
 void LimboUtility::open_doc_introduction() {
-	OS::get_singleton()->shell_open(vformat("https://limboai.readthedocs.io/en/%s/getting-started/introduction.html",
-			LIMBO_DOC_VERSION));
+	OS::get_singleton()->shell_open(vformat("%s/getting-started/introduction.html", LIMBOAI_VERSION_DOC_URL));
 }
 
 void LimboUtility::open_doc_online() {
-	OS::get_singleton()->shell_open(vformat("https://limboai.readthedocs.io/en/%s/index.html",
-			LIMBO_DOC_VERSION));
+	OS::get_singleton()->shell_open(vformat("%s/index.html", LIMBOAI_VERSION_DOC_URL));
 }
 
 void LimboUtility::open_doc_gdextension_limitations() {
-	OS::get_singleton()->shell_open(vformat("https://limboai.readthedocs.io/en/%s/getting-started/gdextension.html#limitations-of-the-gdextension-version",
-			LIMBO_DOC_VERSION));
+	OS::get_singleton()->shell_open(vformat("%s/getting-started/gdextension.html#limitations-of-the-gdextension-version", LIMBOAI_VERSION_DOC_URL));
 }
 
 void LimboUtility::open_doc_custom_tasks() {
-	OS::get_singleton()->shell_open(vformat("https://limboai.readthedocs.io/en/%s/getting-started/custom-tasks.html",
-			LIMBO_DOC_VERSION));
+	OS::get_singleton()->shell_open(vformat("%s/getting-started/custom-tasks.html", LIMBOAI_VERSION_DOC_URL));
 }
 
 void LimboUtility::open_doc_class(const String &p_class_name) {
@@ -596,8 +593,7 @@ void LimboUtility::open_doc_class(const String &p_class_name) {
 #ifdef LIMBOAI_MODULE
 	SHOW_DOC("class_name:" + p_class_name);
 #elif LIMBOAI_GDEXTENSION
-	OS::get_singleton()->shell_open(vformat("https://limboai.readthedocs.io/en/%s/classes/class_%s.html",
-			LIMBO_DOC_VERSION, p_class_name.to_lower()));
+	OS::get_singleton()->shell_open(vformat("%s/classes/class_%s.html", LIMBOAI_VERSION_DOC_URL, p_class_name.to_lower()));
 #endif
 }
 

--- a/util/limbo_utility.h
+++ b/util/limbo_utility.h
@@ -36,8 +36,6 @@ using namespace godot;
 
 #define LOGICAL_XOR(a, b) (a) ? !(b) : (b)
 
-#define LIMBO_DOC_VERSION "latest"
-
 class LimboUtility : public Object {
 	GDCLASS(LimboUtility, Object);
 

--- a/util/limboai_version.h
+++ b/util/limboai_version.h
@@ -1,0 +1,36 @@
+/**
+ * limboai_version.h
+ * =============================================================================
+ * Copyright 2021-2024 Serhii Snitsaruk
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#ifndef LIMBOAI_VERSION_H
+#define LIMBOAI_VERSION_H
+
+#include "limboai_version.gen.h"
+
+#ifdef LIMBOAI_MODULE
+#include "core/string/ustring.h"
+#elif LIMBOAI_GDEXTENSION
+#include <godot_cpp/variant/string.hpp>
+#endif
+
+inline String GET_LIMBOAI_VERSION() {
+	String version = itos(LIMBOAI_VERSION_MAJOR) + "." + itos(LIMBOAI_VERSION_MINOR);
+	if (LIMBOAI_VERSION_PATCH != 0) {
+		version += "." + itos(LIMBOAI_VERSION_PATCH);
+	}
+	if (strlen(LIMBOAI_VERSION_STATUS) > 0) {
+		version += "-" + String(LIMBOAI_VERSION_STATUS);
+	}
+	return version;
+}
+
+#define GET_LIMBOAI_FULL_VERSION() GET_LIMBOAI_VERSION() + " [" + LIMBOAI_VERSION_SHORT_HASH + "]"
+
+#endif // LIMBOAI_VERSION_H


### PR DESCRIPTION
- Version is set in `limboai_version.py` file and hash is taken from GIT on build.
- Click to copy version info into clipboard.

![image](https://github.com/limbonaut/limboai/assets/2766569/6eb3380d-0b96-417c-8109-e4a08cdcc88c)
