### PR TITLE
Fix: GDExtension load fails due to `Expression` used without `Ref<>`

### DIFF
--- a/bt/tasks/utility/bt_evaluate_expression.cpp
+++ b/bt/tasks/utility/bt_evaluate_expression.cpp
@@ -79,7 +79,7 @@ PackedStringArray BTEvaluateExpression::get_configuration_warnings() {
 
 void BTEvaluateExpression::_setup() {
 	parse();
-	ERR_FAIL_COND_MSG(is_parsed != Error::OK, "BTEvaluateExpression: Failed to parse expression: " + expression.get_error_text());
+	ERR_FAIL_COND_MSG(is_parsed != Error::OK, "BTEvaluateExpression: Failed to parse expression: " + expression->get_error_text());
 }
 
 Error BTEvaluateExpression::parse() {
@@ -93,7 +93,7 @@ Error BTEvaluateExpression::parse() {
 		processed_input_names_ptr[i + int(input_include_delta)] = input_names[i];
 	}
 
-	is_parsed = expression.parse(expression_string, processed_input_names);
+	is_parsed = expression->parse(expression_string, processed_input_names);
 	return is_parsed;
 }
 
@@ -109,7 +109,7 @@ BT::Status BTEvaluateExpression::_tick(double p_delta) {
 	ERR_FAIL_COND_V_MSG(node_param.is_null(), FAILURE, "BTEvaluateExpression: Node parameter is not set.");
 	Object *obj = node_param->get_value(get_scene_root(), get_blackboard());
 	ERR_FAIL_COND_V_MSG(obj == nullptr, FAILURE, "BTEvaluateExpression: Failed to get object: " + node_param->to_string());
-	ERR_FAIL_COND_V_MSG(is_parsed != Error::OK, FAILURE, "BTEvaluateExpression: Failed to parse expression: " + expression.get_error_text());
+	ERR_FAIL_COND_V_MSG(is_parsed != Error::OK, FAILURE, "BTEvaluateExpression: Failed to parse expression: " + expression->get_error_text());
 
 	if (input_include_delta) {
 		processed_input_values[0] = p_delta;
@@ -119,8 +119,8 @@ BT::Status BTEvaluateExpression::_tick(double p_delta) {
 		processed_input_values[i + int(input_include_delta)] = bb_variant->get_value(get_scene_root(), get_blackboard());
 	}
 
-	Variant result = expression.execute(processed_input_values, obj, false);
-	ERR_FAIL_COND_V_MSG(expression.has_execute_failed(), FAILURE, "BTEvaluateExpression: Failed to execute: " + expression.get_error_text());
+	Variant result = expression->execute(processed_input_values, obj, false);
+	ERR_FAIL_COND_V_MSG(expression->has_execute_failed(), FAILURE, "BTEvaluateExpression: Failed to execute: " + expression->get_error_text());
 
 	if (result_var != StringName()) {
 		get_blackboard()->set_var(result_var, result);
@@ -156,4 +156,5 @@ void BTEvaluateExpression::_bind_methods() {
 }
 
 BTEvaluateExpression::BTEvaluateExpression() {
+	expression.instantiate();
 }

--- a/bt/tasks/utility/bt_evaluate_expression.h
+++ b/bt/tasks/utility/bt_evaluate_expression.h
@@ -31,7 +31,7 @@ class BTEvaluateExpression : public BTAction {
 	TASK_CATEGORY(Utility);
 
 private:
-	Expression expression;
+	Ref<Expression> expression;
 	Error is_parsed = FAILED;
 	Ref<BBNode> node_param;
 	String expression_string;


### PR DESCRIPTION
GDExtension libraries fail to initialize in Godot 4.3 when a `godot::RefCounted` object is created without initializing its reference counting structure.
