### PR TITLE
Generate built-in documentation header in GDExtension variant

### DIFF
--- a/gdextension/SConstruct
+++ b/gdextension/SConstruct
@@ -40,6 +40,10 @@ sources += Glob("limboai/editor/*.cpp")
 sources += Glob("limboai/hsm/*.cpp")
 sources += Glob("limboai/util/*.cpp")
 
+# Generate documentation header.
+if env["target"] in ["editor", "template_debug"]:
+    doc_data = env.GodotCPPDocData("limboai/gen/doc_data.gen.cpp", source=Glob("limboai/doc_classes/*.xml"))
+    sources.append(doc_data)
 
 if env["platform"] == "macos":
     library = env.SharedLibrary(


### PR DESCRIPTION
Resolves #80
