### PR TITLE
Replace deprecated set_auto_translate call with set_auto_translate_mode

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1506,7 +1506,7 @@ LimboAIEditor::LimboAIEditor() {
 	tab_bar->set_select_with_rmb(true);
 	tab_bar->set_drag_to_rearrange_enabled(true);
 	tab_bar->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
-	tab_bar->set_auto_translate(false);
+	tab_bar->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tab_bar->set_tab_close_display_policy(TabBar::CLOSE_BUTTON_SHOW_ACTIVE_ONLY);
 	tab_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_bar->set_focus_mode(FocusMode::FOCUS_NONE);


### PR DESCRIPTION
Fixes Godot built with deprecated API disabled