### PR TITLE
Improved layout for large displays (optional)

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="LimboAI Demo"
 run/main_scene="res://demo/scenes/showcase.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://demo/assets/icon.svg"
 
 [display]

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1498,14 +1498,14 @@ LimboAIEditor::LimboAIEditor() {
 	misc_btn->set_flat(true);
 	toolbar->add_child(misc_btn);
 
-	HBoxContainer *toolbar_end_hbox = memnew(HBoxContainer);
-	toolbar_end_hbox->set_h_size_flags(SIZE_EXPAND | SIZE_SHRINK_END);
-	toolbar->add_child(toolbar_end_hbox);
+	HBoxContainer *version_hbox = memnew(HBoxContainer);
+	version_hbox->set_h_size_flags(SIZE_EXPAND | SIZE_SHRINK_END);
+	toolbar->add_child(version_hbox);
 
 	TextureRect *logo = memnew(TextureRect);
 	logo->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	logo->set_texture(LimboUtility::get_singleton()->get_task_icon("LimboAI"));
-	toolbar_end_hbox->add_child(logo);
+	version_hbox->add_child(logo);
 
 	version_btn = memnew(LinkButton);
 	version_btn->set_text(TTR("v") + String(GET_LIMBOAI_FULL_VERSION()));
@@ -1513,11 +1513,11 @@ LimboAIEditor::LimboAIEditor() {
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	version_btn->set_v_size_flags(SIZE_SHRINK_CENTER);
-	toolbar_end_hbox->add_child(version_btn);
+	version_hbox->add_child(version_btn);
 
 	Control *version_spacer = memnew(Control);
 	version_spacer->set_custom_minimum_size(Size2(2, 0) * EDSCALE);
-	toolbar_end_hbox->add_child(version_spacer);
+	version_hbox->add_child(version_spacer);
 
 	tab_bar_panel = memnew(PanelContainer);
 	vbox->add_child(tab_bar_panel);
@@ -1568,18 +1568,39 @@ LimboAIEditor::LimboAIEditor() {
 	task_palette = memnew(TaskPalette());
 	task_palette->hide();
 	hsc->add_child(task_palette);
+
 	editor_layout = (EditorLayout)(int)EDITOR_GET("limbo_ai/editor/layout");
 	if (editor_layout == EditorLayout::WIDESCREEN_OPTIMIZED) {
+		// * Alternative layout optimized for wide screen.
+		VBoxContainer *sidebar_vbox = memnew(VBoxContainer);
+		hsc->add_child(sidebar_vbox);
+		sidebar_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+
+		HBoxContainer *header_bar = memnew(HBoxContainer);
+		sidebar_vbox->add_child(header_bar);
+		Control *header_spacer = memnew(Control);
+		header_bar->add_child(header_spacer);
+		header_spacer->set_custom_minimum_size(Size2(6, 0) * EDSCALE);
+		TextureRect *header_logo = Object::cast_to<TextureRect>(logo->duplicate());
+		header_bar->add_child(header_logo);
+		Label *header_title = memnew(Label);
+		header_bar->add_child(header_title);
+		header_title->set_text(TTR("Behavior Tree Editor"));
+		header_title->set_v_size_flags(SIZE_SHRINK_CENTER);
+		header_title->set_theme_type_variation("HeaderMedium");
+
+		task_palette->reparent(sidebar_vbox);
+		task_palette->set_v_size_flags(SIZE_EXPAND_FILL);
+
 		VBoxContainer *editor_vbox = memnew(VBoxContainer);
 		hsc->add_child(editor_vbox);
 		toolbar->reparent(editor_vbox);
 		tab_bar_panel->reparent(editor_vbox);
 		task_tree->reparent(editor_vbox);
 		usage_hint->reparent(editor_vbox);
-		hsc->set_split_offset(300);
-	} else {
-		hsc->set_split_offset(-300);
 	}
+
+	hsc->set_split_offset((editor_layout == EditorLayout::CLASSIC ? -320 : 320) * EDSCALE);
 
 	change_type_popup = memnew(PopupPanel);
 	add_child(change_type_popup);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1377,8 +1377,18 @@ LimboAIEditor::LimboAIEditor() {
 	plugin = nullptr;
 	idx_history = 0;
 
+#ifdef LIMBOAI_MODULE
 	EDITOR_DEF("limbo_ai/editor/layout", 0);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
+	EDITOR_SETTINGS()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
+#elif LIMBOAI_GDEXTENSION
+	EDITOR_SETTINGS()->set_initial_value("limbo_ai/editor/layout", 0, false);
+	Dictionary pinfo;
+	pinfo["name"] = "limbo_ai/editor/layout";
+	pinfo["type"] = Variant::INT;
+	pinfo["hint"] = PROPERTY_HINT_ENUM;
+	pinfo["hint_string"] = "Classic:0,Widescreen Optimized:1";
+	EDITOR_SETTINGS()->add_property_info(pinfo);
+#endif
 
 	LW_SHORTCUT("limbo_ai/rename_task", TTR("Rename"), LW_KEY(F2));
 	// Todo: Add override support for shortcuts.

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1377,6 +1377,9 @@ LimboAIEditor::LimboAIEditor() {
 	plugin = nullptr;
 	idx_history = 0;
 
+	EDITOR_DEF("limbo_ai/editor/layout", 0);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
+
 	LW_SHORTCUT("limbo_ai/rename_task", TTR("Rename"), LW_KEY(F2));
 	// Todo: Add override support for shortcuts.
 	// LW_SHORTCUT_OVERRIDE("limbo_ai/rename_task", "macos", Key::ENTER);
@@ -1546,8 +1549,8 @@ LimboAIEditor::LimboAIEditor() {
 	task_palette = memnew(TaskPalette());
 	task_palette->hide();
 	hsc->add_child(task_palette);
-	TaskPalettePlacement palette_placement = (TaskPalettePlacement)(int)EDITOR_GET("limbo_ai/editor/task_palette_placement");
-	if (palette_placement == TaskPalettePlacement::LEFT_SIDE) {
+	editor_layout = (EditorLayout)(int)EDITOR_GET("limbo_ai/editor/layout");
+	if (editor_layout == EditorLayout::WIDESCREEN_OPTIMIZED) {
 		VBoxContainer *editor_vbox = memnew(VBoxContainer);
 		hsc->add_child(editor_vbox);
 		toolbar->reparent(editor_vbox);
@@ -1664,9 +1667,6 @@ LimboAIEditor::LimboAIEditor() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_1", PROPERTY_HINT_DIR), "res://ai/tasks");
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_2", PROPERTY_HINT_DIR), "");
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_3", PROPERTY_HINT_DIR), "");
-
-	EDITOR_DEF("limbo_ai/editor/task_palette_placement", 0);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/task_palette_placement", PROPERTY_HINT_ENUM, "Right Side:0,Left Side:1"));
 
 	String bt_default_dir = GLOBAL_GET("limbo_ai/behavior_tree/behavior_tree_default_dir");
 	save_dialog->set_current_dir(bt_default_dir);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1544,9 +1544,15 @@ LimboAIEditor::LimboAIEditor() {
 	usage_hint->add_child(usage_label);
 
 	task_palette = memnew(TaskPalette());
-	hsc->set_split_offset(-300);
 	task_palette->hide();
 	hsc->add_child(task_palette);
+	TaskPalettePlacement palette_placement = (TaskPalettePlacement)(int)EDITOR_GET("limbo_ai/editor/task_palette_placement");
+	if (palette_placement == TaskPalettePlacement::LEFT_SIDE) {
+		hsc->move_child(task_palette, 0);
+		hsc->set_split_offset(300);
+	} else {
+		hsc->set_split_offset(-300);
+	}
 
 	change_type_popup = memnew(PopupPanel);
 	add_child(change_type_popup);
@@ -1653,6 +1659,9 @@ LimboAIEditor::LimboAIEditor() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_1", PROPERTY_HINT_DIR), "res://ai/tasks");
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_2", PROPERTY_HINT_DIR), "");
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/user_task_dir_3", PROPERTY_HINT_DIR), "");
+
+	EDITOR_DEF("limbo_ai/editor/task_palette_placement", 0);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/task_palette_placement", PROPERTY_HINT_ENUM, "Right Side:0,Left Side:1"));
 
 	String bt_default_dir = GLOBAL_GET("limbo_ai/behavior_tree/behavior_tree_default_dir");
 	save_dialog->set_current_dir(bt_default_dir);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_help.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -318,8 +319,8 @@ void LimboAIEditor::_remove_task_from_favorite(const String &p_task) {
 
 void LimboAIEditor::_save_and_restart() {
 	ProjectSettings::get_singleton()->save();
-	EditorNode::get_singleton()->save_all_scenes();
-	EditorNode::get_singleton()->restart_editor();
+	EditorInterface::get_singleton()->save_all_scenes();
+	EditorInterface::get_singleton()->restart_editor(true);
 }
 
 void LimboAIEditor::_extract_subtree(const String &p_path) {
@@ -707,12 +708,12 @@ void LimboAIEditor::_misc_option_selected(int p_id) {
 		} break;
 		case MISC_LAYOUT_CLASSIC: {
 			EDITOR_SETTINGS()->set_setting("limbo_ai/editor/layout", LAYOUT_CLASSIC);
-			EDITOR_SETTINGS()->save();
+			EDITOR_SETTINGS()->mark_setting_changed("limbo_ai/editor/layout");
 			_update_banners();
 		} break;
 		case MISC_LAYOUT_WIDESCREEN_OPTIMIZED: {
 			EDITOR_SETTINGS()->set_setting("limbo_ai/editor/layout", LAYOUT_WIDESCREEN_OPTIMIZED);
-			EDITOR_SETTINGS()->save();
+			EDITOR_SETTINGS()->mark_setting_changed("limbo_ai/editor/layout");
 			_update_banners();
 		} break;
 		case MISC_CREATE_SCRIPT_TEMPLATE: {

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1401,7 +1401,12 @@ void LimboAIEditor::_notification(int p_what) {
 			BUTTON_SET_ICON(misc_btn, get_theme_icon(LW_NAME(Tools), LW_NAME(EditorIcons)));
 
 			_update_favorite_tasks();
-		}
+		} break;
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (is_visible_in_tree()) {
+				_update_banners();
+			}
+		} break;
 	}
 }
 

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1294,7 +1294,12 @@ void LimboAIEditor::_notification(int p_what) {
 			cf.instantiate();
 			String conf_path = PROJECT_CONFIG_FILE();
 			cf->load(conf_path);
-			cf->set_value("bt_editor", "bteditor_hsplit", hsc->get_split_offset());
+			int split_offset = hsc->get_split_offset();
+			if (editor_layout != (int)EDITOR_GET("limbo_ai/editor/layout")) {
+				// Editor layout settings changed - flip split offset.
+				split_offset *= -1;
+			}
+			cf->set_value("bt_editor", "bteditor_hsplit", split_offset);
 			cf->save(conf_path);
 
 			if (task_tree->get_bt().is_valid() &&
@@ -1380,6 +1385,7 @@ LimboAIEditor::LimboAIEditor() {
 #ifdef LIMBOAI_MODULE
 	EDITOR_DEF("limbo_ai/editor/layout", 0);
 	EDITOR_SETTINGS()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
+	EDITOR_SETTINGS()->set_restart_if_changed("limbo_ai/editor/layout", true);
 #elif LIMBOAI_GDEXTENSION
 	EDITOR_SETTINGS()->set_initial_value("limbo_ai/editor/layout", 0, false);
 	Dictionary pinfo;

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1291,7 +1291,7 @@ void LimboAIEditor::_update_banners() {
 	EditorLayout saved_layout = (EditorLayout)(int)EDITOR_GET("limbo_ai/editor/layout");
 	if (saved_layout != editor_layout) {
 		ActionBanner *banner = memnew(ActionBanner);
-		banner->set_text(TTR("Restart required to apply changes to editor layout."));
+		banner->set_text(TTR("Restart required to apply changes to editor layout"));
 		banner->add_action(TTR("Save & Restart"), callable_mp(this, &LimboAIEditor::_save_and_restart), true);
 		banner->set_meta(LW_NAME(managed), Variant(true));
 		banners->call_deferred(LW_NAME(add_child), banner);
@@ -1608,6 +1608,9 @@ LimboAIEditor::LimboAIEditor() {
 	task_palette->hide();
 	hsc->add_child(task_palette);
 
+	banners = memnew(VBoxContainer);
+	vbox->add_child(banners);
+
 	editor_layout = (EditorLayout)(int)EDITOR_GET("limbo_ai/editor/layout");
 	if (editor_layout == LAYOUT_WIDESCREEN_OPTIMIZED) {
 		// * Alternative layout optimized for wide screen.
@@ -1637,6 +1640,7 @@ LimboAIEditor::LimboAIEditor() {
 		tab_bar_panel->reparent(editor_vbox);
 		task_tree->reparent(editor_vbox);
 		usage_hint->reparent(editor_vbox);
+		banners->reparent(editor_vbox);
 	}
 
 	hsc->set_split_offset((editor_layout == LAYOUT_CLASSIC ? -320 : 320) * EDSCALE);
@@ -1658,9 +1662,6 @@ LimboAIEditor::LimboAIEditor() {
 		change_type_palette->use_dialog_mode();
 		change_type_palette->set_v_size_flags(SIZE_EXPAND_FILL);
 	}
-
-	banners = memnew(VBoxContainer);
-	vbox->add_child(banners);
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1548,7 +1548,12 @@ LimboAIEditor::LimboAIEditor() {
 	hsc->add_child(task_palette);
 	TaskPalettePlacement palette_placement = (TaskPalettePlacement)(int)EDITOR_GET("limbo_ai/editor/task_palette_placement");
 	if (palette_placement == TaskPalettePlacement::LEFT_SIDE) {
-		hsc->move_child(task_palette, 0);
+		VBoxContainer *editor_vbox = memnew(VBoxContainer);
+		hsc->add_child(editor_vbox);
+		toolbar->reparent(editor_vbox);
+		tab_bar_panel->reparent(editor_vbox);
+		task_tree->reparent(editor_vbox);
+		usage_hint->reparent(editor_vbox);
 		hsc->set_split_offset(300);
 	} else {
 		hsc->set_split_offset(-300);

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -111,9 +111,9 @@ private:
 		TAB_CLOSE_ALL,
 	};
 
-	enum TaskPalettePlacement {
-		RIGHT_SIDE,
-		LEFT_SIDE,
+	enum EditorLayout {
+		CLASSIC,
+		WIDESCREEN_OPTIMIZED,
 	};
 
 	struct ThemeCache {
@@ -137,6 +137,7 @@ private:
 	} theme_cache;
 
 	EditorPlugin *plugin;
+	EditorLayout editor_layout;
 	Vector<Ref<BehaviorTree>> history;
 	int idx_history;
 	bool updating_tabs = false;

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -26,8 +26,8 @@
 #include "core/object/object.h"
 #include "core/templates/hash_set.h"
 #include "editor/editor_node.h"
-#include "editor/plugins/editor_plugin.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
@@ -109,6 +109,11 @@ private:
 		TAB_CLOSE_OTHER,
 		TAB_CLOSE_RIGHT,
 		TAB_CLOSE_ALL,
+	};
+
+	enum TaskPalettePlacement {
+		RIGHT_SIDE,
+		LEFT_SIDE,
 	};
 
 	struct ThemeCache {

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -98,6 +98,8 @@ private:
 		MISC_DOC_INTRODUCTION,
 		MISC_DOC_CUSTOM_TASKS,
 		MISC_OPEN_DEBUGGER,
+		MISC_LAYOUT_CLASSIC,
+		MISC_LAYOUT_WIDESCREEN_OPTIMIZED,
 		MISC_PROJECT_SETTINGS,
 		MISC_CREATE_SCRIPT_TEMPLATE,
 	};
@@ -112,8 +114,8 @@ private:
 	};
 
 	enum EditorLayout {
-		CLASSIC,
-		WIDESCREEN_OPTIMIZED,
+		LAYOUT_CLASSIC,
+		LAYOUT_WIDESCREEN_OPTIMIZED,
 	};
 
 	struct ThemeCache {
@@ -201,6 +203,7 @@ private:
 	void _mark_as_dirty(bool p_dirty);
 	void _create_user_task_dir();
 	void _remove_task_from_favorite(const String &p_task);
+	void _save_and_restart();
 	void _extract_subtree(const String &p_path);
 	void _replace_task(const Ref<BTTask> &p_task, const Ref<BTTask> &p_by_task);
 


### PR DESCRIPTION
New layout optimized for widescreen displays, with task palette on the left side. It is optional and can be enabled in the editor settings in `limbo_ai/editor/layout` or using `Misc->Layout` menu.

![image](https://github.com/limbonaut/limboai/assets/2766569/cadcaa5a-3b32-4fea-bbae-9cc5178360e8)
Resolves #153