### PR TITLE
Fix BlackboardPlan arrays shouldn't be shared between instanced agents

### DIFF
--- a/blackboard/bb_variable.cpp
+++ b/blackboard/bb_variable.cpp
@@ -78,12 +78,16 @@ String BBVariable::get_hint_string() const {
 	return data->hint_string;
 }
 
-BBVariable BBVariable::duplicate() const {
+BBVariable BBVariable::duplicate(bool p_deep) const {
 	BBVariable var;
 	var.data->hint = data->hint;
 	var.data->hint_string = data->hint_string;
 	var.data->type = data->type;
-	var.data->value = data->value;
+	if (p_deep) {
+		var.data->value = data->value.duplicate(p_deep);
+	} else {
+		var.data->value = data->value;
+	}
 	var.data->binding_path = data->binding_path;
 	var.data->bound_object = data->bound_object;
 	var.data->bound_property = data->bound_property;

--- a/blackboard/bb_variable.h
+++ b/blackboard/bb_variable.h
@@ -54,7 +54,7 @@ public:
 	void set_hint_string(const String &p_hint_string);
 	String get_hint_string() const;
 
-	BBVariable duplicate() const;
+	BBVariable duplicate(bool p_deep = false) const;
 
 	_FORCE_INLINE_ bool is_value_changed() const { return data->value_changed; }
 	_FORCE_INLINE_ void reset_value_changed() { data->value_changed = false; }

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -391,7 +391,7 @@ void BlackboardPlan::sync_with_base_plan() {
 inline void bb_add_var_dup_with_prefetch(const Ref<Blackboard> &p_blackboard, const StringName &p_name, const BBVariable &p_var, bool p_prefetch, Node *p_node) {
 	if (unlikely(p_prefetch && p_var.get_type() == Variant::NODE_PATH)) {
 		Node *n = p_node->get_node_or_null(p_var.get_value());
-		BBVariable var = p_var.duplicate();
+		BBVariable var = p_var.duplicate(true);
 		if (n != nullptr) {
 			var.set_value(n);
 		} else {
@@ -404,7 +404,7 @@ inline void bb_add_var_dup_with_prefetch(const Ref<Blackboard> &p_blackboard, co
 		}
 		p_blackboard->assign_var(p_name, var);
 	} else {
-		p_blackboard->assign_var(p_name, p_var.duplicate());
+		p_blackboard->assign_var(p_name, p_var.duplicate(true));
 	}
 }
 


### PR DESCRIPTION
Variable values are now deep copied using Variant.duplicate(true). Note that currently it doesn't duplicate objects.