### PR TITLE
Fix new task script path don't update after changing the setting

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -903,6 +903,10 @@ void LimboAIEditor::_on_resources_reload(const PackedStringArray &p_resources) {
 #endif
 }
 
+void LimboAIEditor::_on_new_script_pressed() {
+	SCRIPT_EDITOR()->open_script_create_dialog("BTAction", String(GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir_1")).path_join("new_task"));
+}
+
 void LimboAIEditor::_task_type_selected(const String &p_class_or_path) {
 	change_type_popup->hide();
 
@@ -1378,7 +1382,7 @@ void LimboAIEditor::_notification(int p_what) {
 			disk_changed->connect("confirmed", callable_mp(this, &LimboAIEditor::_reload_modified));
 			disk_changed->connect("custom_action", callable_mp(this, &LimboAIEditor::_resave_modified));
 			rename_dialog->connect("confirmed", callable_mp(this, &LimboAIEditor::_rename_task_confirmed));
-			new_script_btn->connect(LW_NAME(pressed), callable_mp(SCRIPT_EDITOR(), &ScriptEditor::open_script_create_dialog).bind("BTAction", String(GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir_1")).path_join("new_task")));
+			new_script_btn->connect(LW_NAME(pressed), callable_mp(this, &LimboAIEditor::_on_new_script_pressed));
 			tab_bar->connect("tab_clicked", callable_mp(this, &LimboAIEditor::_tab_clicked));
 			tab_bar->connect("active_tab_rearranged", callable_mp(this, &LimboAIEditor::_move_active_tab));
 			tab_bar->connect("tab_close_pressed", callable_mp(this, &LimboAIEditor::_tab_closed));

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -236,6 +236,7 @@ private:
 	void _on_history_forward();
 	void _on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, int p_type);
 	void _on_resources_reload(const PackedStringArray &p_resources);
+	void _on_new_script_pressed();
 	void _task_type_selected(const String &p_class_or_path);
 	void _copy_version_info();
 


### PR DESCRIPTION
The path of the "New Task" button doesn't update when the setting is changed and requires restarting the editor to take effect.
This change makes it use the current value.