### PR TITLE
Fix error when opening scene with a `BTPlayer`

### DIFF
--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -214,10 +214,10 @@ void BTPlayer::_notification(int p_notification) {
 				if (behavior_tree.is_valid()) {
 					_load_tree();
 				}
-				set_active(active);
 			} else {
 				_update_blackboard_plan();
 			}
+			set_active(active);
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
When I open a scene that contains a `BTPlayer` in the editor, it always gives this:

> BTPlayer doesn't have a behavior tree with a valid root task to execute [...]

That's because the process notification is still enabled although it doesn't load the behavior tree in the editor.