### PR TITLE
Allow monitoring BT performance in `BTState`

### DIFF
--- a/bt/bt_state.cpp
+++ b/bt/bt_state.cpp
@@ -37,6 +37,16 @@ void BTState::set_behavior_tree(const Ref<BehaviorTree> &p_tree) {
 	_update_blackboard_plan();
 }
 
+#ifdef DEBUG_ENABLED
+void BTState::_set_monitor_performance(bool p_monitor) {
+	monitor_performance = p_monitor;
+
+	if (bt_instance.is_valid()) {
+		bt_instance->set_monitor_performance(monitor_performance);
+	}
+}
+#endif // DEBUG_ENABLED
+
 void BTState::_update_blackboard_plan() {
 	if (get_blackboard_plan().is_null()) {
 		set_blackboard_plan(memnew(BlackboardPlan));
@@ -58,6 +68,7 @@ void BTState::_setup() {
 
 #ifdef DEBUG_ENABLED
 	bt_instance->register_with_debugger();
+	bt_instance->set_monitor_performance(monitor_performance);
 #endif
 }
 
@@ -92,6 +103,7 @@ void BTState::_notification(int p_notification) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (bt_instance.is_valid()) {
 				bt_instance->register_with_debugger();
+				bt_instance->set_monitor_performance(monitor_performance);
 			}
 		} break;
 #endif // DEBUG_ENABLED
@@ -99,7 +111,9 @@ void BTState::_notification(int p_notification) {
 #ifdef DEBUG_ENABLED
 			if (bt_instance.is_valid()) {
 				bt_instance->unregister_with_debugger();
+				bt_instance->set_monitor_performance(false);
 			}
+
 #endif // DEBUG_ENABLED
 
 			if (Engine::get_singleton()->is_editor_hint()) {
@@ -126,6 +140,12 @@ void BTState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "behavior_tree", PROPERTY_HINT_RESOURCE_TYPE, "BehaviorTree"), "set_behavior_tree", "get_behavior_tree");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "success_event"), "set_success_event", "get_success_event");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "failure_event"), "set_failure_event", "get_failure_event");
+
+#ifdef DEBUG_ENABLED
+	ClassDB::bind_method(D_METHOD("_set_monitor_performance", "enable"), &BTState::_set_monitor_performance);
+	ClassDB::bind_method(D_METHOD("_get_monitor_performance"), &BTState::_get_monitor_performance);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitor_performance"), "_set_monitor_performance", "_get_monitor_performance");
+#endif // DEBUG_ENABLED
 }
 
 BTState::BTState() {

--- a/bt/bt_state.h
+++ b/bt/bt_state.h
@@ -51,6 +51,14 @@ public:
 	StringName get_failure_event() const { return failure_event; }
 
 	BTState();
+
+#ifdef DEBUG_ENABLED
+private:
+	bool monitor_performance = false;
+
+	void _set_monitor_performance(bool p_monitor);
+	bool _get_monitor_performance() const { return monitor_performance; }
+#endif
 };
 
 #endif // BT_STATE_H

--- a/doc/source/classes/class_btstate.rst
+++ b/doc/source/classes/class_btstate.rst
@@ -29,13 +29,15 @@ Properties
 .. table::
    :widths: auto
 
-   +-----------------------------------------+------------------------------------------------------------+----------------+
-   | :ref:`BehaviorTree<class_BehaviorTree>` | :ref:`behavior_tree<class_BTState_property_behavior_tree>` |                |
-   +-----------------------------------------+------------------------------------------------------------+----------------+
-   | ``StringName``                          | :ref:`failure_event<class_BTState_property_failure_event>` | ``&"failure"`` |
-   +-----------------------------------------+------------------------------------------------------------+----------------+
-   | ``StringName``                          | :ref:`success_event<class_BTState_property_success_event>` | ``&"success"`` |
-   +-----------------------------------------+------------------------------------------------------------+----------------+
+   +-----------------------------------------+------------------------------------------------------------------------+----------------+
+   | :ref:`BehaviorTree<class_BehaviorTree>` | :ref:`behavior_tree<class_BTState_property_behavior_tree>`             |                |
+   +-----------------------------------------+------------------------------------------------------------------------+----------------+
+   | ``StringName``                          | :ref:`failure_event<class_BTState_property_failure_event>`             | ``&"failure"`` |
+   +-----------------------------------------+------------------------------------------------------------------------+----------------+
+   | ``bool``                                | :ref:`monitor_performance<class_BTState_property_monitor_performance>` | ``false``      |
+   +-----------------------------------------+------------------------------------------------------------------------+----------------+
+   | ``StringName``                          | :ref:`success_event<class_BTState_property_success_event>`             | ``&"success"`` |
+   +-----------------------------------------+------------------------------------------------------------------------+----------------+
 
 .. rst-class:: classref-reftable-group
 
@@ -87,6 +89,18 @@ A :ref:`BehaviorTree<class_BehaviorTree>` resource that defines state behavior.
 - ``StringName`` **get_failure_event**\ (\ )
 
 HSM event that will be dispatched when the behavior tree results in ``FAILURE``. See :ref:`LimboState.dispatch<class_LimboState_method_dispatch>`.
+
+.. rst-class:: classref-item-separator
+
+----
+
+.. _class_BTState_property_monitor_performance:
+
+.. rst-class:: classref-property
+
+``bool`` **monitor_performance** = ``false`` :ref:`🔗<class_BTState_property_monitor_performance>`
+
+If ``true``, adds a performance monitor to "Debugger->Monitors" for each instance of this **BTState** node.
 
 .. rst-class:: classref-item-separator
 

--- a/doc_classes/BTState.xml
+++ b/doc_classes/BTState.xml
@@ -23,6 +23,9 @@
 		<member name="failure_event" type="StringName" setter="set_failure_event" getter="get_failure_event" default="&amp;&quot;failure&quot;">
 			HSM event that will be dispatched when the behavior tree results in [code]FAILURE[/code]. See [method LimboState.dispatch].
 		</member>
+		<member name="monitor_performance" type="bool" setter="_set_monitor_performance" getter="_get_monitor_performance" default="false">
+			If [code]true[/code], adds a performance monitor to "Debugger-&gt;Monitors" for each instance of this [BTState] node.
+		</member>
 		<member name="success_event" type="StringName" setter="set_success_event" getter="get_success_event" default="&amp;&quot;success&quot;">
 			HSM event that will be dispatched when the behavior tree results in [code]SUCCESS[/code]. See [method LimboState.dispatch].
 		</member>


### PR DESCRIPTION
Adds `monitor_performance` property to `BTState`