### PR TITLE
Editor setting to prefer online docs, and open builtin docs by default

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1434,12 +1434,13 @@ LimboAIEditor::LimboAIEditor() {
 	plugin = nullptr;
 	idx_history = 0;
 
-#ifdef LIMBOAI_MODULE
+	EDITOR_DEF("limbo_ai/editor/prefer_online_documentation", false);
+
 	EDITOR_DEF("limbo_ai/editor/layout", 0);
+#ifdef LIMBOAI_MODULE
 	EDITOR_SETTINGS()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
 	EDITOR_SETTINGS()->set_restart_if_changed("limbo_ai/editor/layout", true);
 #elif LIMBOAI_GDEXTENSION
-	EDITOR_SETTINGS()->set_initial_value("limbo_ai/editor/layout", 0, false);
 	Dictionary pinfo;
 	pinfo["name"] = "limbo_ai/editor/layout";
 	pinfo["type"] = Variant::INT;

--- a/util/limbo_compat.cpp
+++ b/util/limbo_compat.cpp
@@ -210,7 +210,7 @@ Variant VARIANT_DEFAULT(Variant::Type p_type) {
 
 #ifdef TOOLS_ENABLED
 
-void SHOW_DOC(const String &p_topic) {
+void SHOW_BUILTIN_DOC(const String &p_topic) {
 #ifdef LIMBOAI_MODULE
 	ScriptEditor::get_singleton()->goto_help(p_topic);
 	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);

--- a/util/limbo_compat.h
+++ b/util/limbo_compat.h
@@ -114,6 +114,7 @@ using namespace godot;
 #define ADD_STYLEBOX_OVERRIDE(m_control, m_name, m_stylebox) (m_control->add_theme_stylebox_override(m_name, m_stylebox))
 #define GET_NODE(m_parent, m_path) m_parent->get_node_internal(m_path)
 #define OBJECT_DB_GET_INSTANCE(m_id) ObjectDB::get_instance(m_id)
+#define EDITOR_DEF(m_setting, m_value) EditorInterface::get_singleton()->get_editor_settings()->set_initial_value(m_setting, m_value, false)
 
 _FORCE_INLINE_ bool OBJECT_HAS_PROPERTY(Object *p_obj, const StringName &p_prop) {
 	return Variant(p_obj).has_key(p_prop);
@@ -172,7 +173,7 @@ Variant VARIANT_DEFAULT(Variant::Type p_type);
 
 #ifdef TOOLS_ENABLED
 
-void SHOW_DOC(const String &p_topic);
+void SHOW_BUILTIN_DOC(const String &p_topic);
 void EDIT_SCRIPT(const String &p_path);
 
 #endif // TOOLS_ENABLED

--- a/util/limbo_utility.cpp
+++ b/util/limbo_utility.cpp
@@ -25,6 +25,7 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #endif // TOOLS_ENABLED
 
 #endif // ! LIMBOAI_MODULE
@@ -569,33 +570,41 @@ Ref<Shortcut> LimboUtility::get_shortcut(const String &p_path) const {
 	return nullptr;
 }
 
+inline void _open_online_doc_page(const String &p_page) {
+	OS::get_singleton()->shell_open(vformat("%s/%s", LIMBOAI_VERSION_DOC_URL, p_page));
+}
+
 void LimboUtility::open_doc_introduction() {
-	OS::get_singleton()->shell_open(vformat("%s/getting-started/introduction.html", LIMBOAI_VERSION_DOC_URL));
+	_open_online_doc_page("getting-started/introduction.html");
 }
 
 void LimboUtility::open_doc_online() {
-	OS::get_singleton()->shell_open(vformat("%s/index.html", LIMBOAI_VERSION_DOC_URL));
+	_open_online_doc_page("index.html");
 }
 
 void LimboUtility::open_doc_gdextension_limitations() {
-	OS::get_singleton()->shell_open(vformat("%s/getting-started/gdextension.html#limitations-of-the-gdextension-version", LIMBOAI_VERSION_DOC_URL));
+	_open_online_doc_page("getting-started/gdextension.html#limitations-of-the-gdextension-version");
 }
 
 void LimboUtility::open_doc_custom_tasks() {
-	OS::get_singleton()->shell_open(vformat("%s/getting-started/custom-tasks.html", LIMBOAI_VERSION_DOC_URL));
+	_open_online_doc_page("getting-started/custom-tasks.html");
 }
 
 void LimboUtility::open_doc_class(const String &p_class_name) {
 	if (p_class_name.begins_with("res://")) {
-		SHOW_DOC(vformat("class_name:\"%s\"", p_class_name));
+		// ! FIXME: Opening script documentation is unreliable in Godot, because script
+		// !        documentation is only parsed when script is re-saved in the script editor.
+		// ! Workaround: Opening script in the editor instead...
+		EDIT_SCRIPT(p_class_name);
+		// SHOW_DOC(vformat("class_name:\"%s\"", p_class_name.trim_prefix("res://")));
 		return;
 	}
 
-#ifdef LIMBOAI_MODULE
-	SHOW_DOC("class_name:" + p_class_name);
-#elif LIMBOAI_GDEXTENSION
-	OS::get_singleton()->shell_open(vformat("%s/classes/class_%s.html", LIMBOAI_VERSION_DOC_URL, p_class_name.to_lower()));
-#endif
+	if (EDITOR_GET("limbo_ai/editor/prefer_online_documentation")) {
+		_open_online_doc_page(vformat("classes/class_%s.html", p_class_name.to_lower()));
+	} else {
+		SHOW_BUILTIN_DOC("class_name:" + p_class_name);
+	}
 }
 
 #endif // ! TOOLS_ENABLED


### PR DESCRIPTION
Also, currently, opening script documentation is unreliable in Godot, because documentation is only parsed when script is re-saved in the editor. As a workaround, this PR makes the editor open script source instead.