### PR TITLE
Fix renaming `BehaviorTree` files doesn't update tab names

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -799,6 +799,11 @@ void LimboAIEditor::_on_visibility_changed() {
 		task_palette->refresh();
 	}
 	_update_favorite_tasks();
+
+	if (request_update_tabs && history.size() > 0) {
+		_update_tabs();
+		request_update_tabs = false;
+	}
 }
 
 void LimboAIEditor::_on_header_pressed() {
@@ -912,6 +917,18 @@ void LimboAIEditor::_on_resources_reload(const PackedStringArray &p_resources) {
 #elif LIMBOAI_GDEXTENSION
 	task_tree->update_tree();
 #endif
+}
+
+void LimboAIEditor::_on_filesystem_changed() {
+	if (history.size() == 0) {
+		return;
+	}
+
+	if (is_visible_in_tree()) {
+		_update_tabs();
+	} else {
+		request_update_tabs = true;
+	}
 }
 
 void LimboAIEditor::_on_new_script_pressed() {
@@ -1403,6 +1420,7 @@ void LimboAIEditor::_notification(int p_what) {
 			version_btn->connect(LW_NAME(pressed), callable_mp(this, &LimboAIEditor::_copy_version_info));
 
 			EDITOR_FILE_SYSTEM()->connect("resources_reload", callable_mp(this, &LimboAIEditor::_on_resources_reload));
+			EDITOR_FILE_SYSTEM()->connect("filesystem_changed", callable_mp(this, &LimboAIEditor::_on_filesystem_changed));
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -143,6 +143,7 @@ private:
 	Vector<Ref<BehaviorTree>> history;
 	int idx_history;
 	bool updating_tabs = false;
+	bool request_update_tabs = false;
 	HashSet<Ref<BehaviorTree>> dirty;
 	Ref<BTTask> clipboard_task;
 
@@ -237,6 +238,7 @@ private:
 	void _on_history_forward();
 	void _on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, int p_type);
 	void _on_resources_reload(const PackedStringArray &p_resources);
+	void _on_filesystem_changed();
 	void _on_new_script_pressed();
 	void _task_type_selected(const String &p_class_or_path);
 	void _copy_version_info();


### PR DESCRIPTION
Tab names don't update when a built-in behavior tree is saved as a file or renamed. This PR makes it update if any are open.