### PR TITLE
Don't overwrite exisiting blackboard variables in `BTState` upon initialization

### DIFF
--- a/blackboard/blackboard.h
+++ b/blackboard/blackboard.h
@@ -49,6 +49,7 @@ public:
 	Variant get_var(const StringName &p_name, const Variant &p_default = Variant(), bool p_complain = true) const;
 	void set_var(const StringName &p_name, const Variant &p_value);
 	bool has_var(const StringName &p_name) const;
+	_FORCE_INLINE_ bool has_local_var(const StringName &p_name) const { return data.has(p_name); }
 	void erase_var(const StringName &p_name);
 	void clear() { data.clear(); }
 	TypedArray<StringName> list_vars() const;

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -417,6 +417,12 @@ void BlackboardPlan::populate_blackboard(const Ref<Blackboard> &p_blackboard, bo
 	ERR_FAIL_COND(p_blackboard.is_null());
 	for (const Pair<StringName, BBVariable> &p : var_list) {
 		if (p_blackboard->has_local_var(p.first) && !overwrite) {
+			Variant::Type existing_type = p_blackboard->get_var(p.first).get_type();
+			Variant::Type planned_type = p.second.get_type();
+			if (existing_type != planned_type && existing_type != Variant::NIL && planned_type != Variant::NIL) {
+				WARN_PRINT(vformat("BlackboardPlan: Not overwriting %s as it already exists in the blackboard, but it has a different type than planned (%s vs %s). File: %s",
+						LimboUtility::get_singleton()->decorate_var(p.first), Variant::get_type_name(existing_type), Variant::get_type_name(planned_type), get_path()));
+			}
 			continue;
 		}
 		bool has_mapping = parent_scope_mapping.has(p.first);
@@ -425,7 +431,7 @@ void BlackboardPlan::populate_blackboard(const Ref<Blackboard> &p_blackboard, bo
 		if (has_mapping) {
 			StringName target_var = parent_scope_mapping[p.first];
 			if (target_var != StringName()) {
-				ERR_CONTINUE_MSG(p_blackboard->get_parent() == nullptr, vformat("BlackboardPlan: Cannot link variable $%s to parent scope because the parent scope is not set.", p.first));
+				ERR_CONTINUE_MSG(p_blackboard->get_parent() == nullptr, vformat("BlackboardPlan: Cannot link variable %s to parent scope because the parent scope is not set.", LimboUtility::get_singleton()->decorate_var(p.first)));
 				p_blackboard->link_var(p.first, p_blackboard->get_parent(), target_var);
 			}
 		}

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -416,7 +416,7 @@ void BlackboardPlan::populate_blackboard(const Ref<Blackboard> &p_blackboard, bo
 	ERR_FAIL_COND(p_node == nullptr && prefetch_nodepath_vars);
 	ERR_FAIL_COND(p_blackboard.is_null());
 	for (const Pair<StringName, BBVariable> &p : var_list) {
-		if (p_blackboard->has_var(p.first) && !overwrite) {
+		if (p_blackboard->has_local_var(p.first) && !overwrite) {
 			continue;
 		}
 		bool has_mapping = parent_scope_mapping.has(p.first);

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -417,12 +417,14 @@ void BlackboardPlan::populate_blackboard(const Ref<Blackboard> &p_blackboard, bo
 	ERR_FAIL_COND(p_blackboard.is_null());
 	for (const Pair<StringName, BBVariable> &p : var_list) {
 		if (p_blackboard->has_local_var(p.first) && !overwrite) {
+#ifdef DEBUG_ENABLED
 			Variant::Type existing_type = p_blackboard->get_var(p.first).get_type();
 			Variant::Type planned_type = p.second.get_type();
-			if (existing_type != planned_type && existing_type != Variant::NIL && planned_type != Variant::NIL) {
+			if (existing_type != planned_type && existing_type != Variant::NIL && planned_type != Variant::NIL && !(existing_type == Variant::OBJECT && planned_type == Variant::NODE_PATH)) {
 				WARN_PRINT(vformat("BlackboardPlan: Not overwriting %s as it already exists in the blackboard, but it has a different type than planned (%s vs %s). File: %s",
 						LimboUtility::get_singleton()->decorate_var(p.first), Variant::get_type_name(existing_type), Variant::get_type_name(planned_type), get_path()));
 			}
+#endif
 			continue;
 		}
 		bool has_mapping = parent_scope_mapping.has(p.first);

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -183,6 +183,7 @@ void BTPlayer::_notification(int p_notification) {
 					blackboard = Ref<Blackboard>(memnew(Blackboard));
 				}
 				if (blackboard_plan.is_valid()) {
+					// Don't overwrite existing blackboard values as they may be initialized from code.
 					blackboard_plan->populate_blackboard(blackboard, false, this);
 				}
 				if (behavior_tree.is_valid()) {

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -95,7 +95,8 @@ void LimboState::_initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard)
 		blackboard = p_blackboard;
 	}
 	if (blackboard_plan.is_valid() && !blackboard_plan->is_empty()) {
-		blackboard_plan->populate_blackboard(blackboard, true, this);
+		// Don't overwrite existing blackboard values as they may be initialized from code.
+		blackboard_plan->populate_blackboard(blackboard, false, this);
 	}
 
 	_setup();


### PR DESCRIPTION
Variables can be initialized from code, and it should be supported.
Also, warn if the type of existing variable is different from the planned.
