### PR TITLE
Fix editor undo polluting scene history if `BehaviorTree` is not saved to a file

### DIFF
--- a/bt/bt_instance.cpp
+++ b/bt/bt_instance.cpp
@@ -43,7 +43,7 @@ BT::Status BTInstance::update(double p_delta) {
 #endif
 
 	last_status = root_task->execute(p_delta);
-	emit_signal(LimboStringNames::get_singleton()->updated, last_status);
+	emit_signal(LW_NAME(updated), last_status);
 
 #ifdef DEBUG_ENABLED
 	double end = Time::get_singleton()->get_ticks_usec();

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -125,6 +125,7 @@ String BTTask::get_task_name() {
 	Ref<Script> task_script = get_script();
 
 	if (task_script.is_valid()) {
+		// ! CURSED: Currently, has_method() doesn't return true for ClassDB-registered native virtual methods. This may break in the future.
 		bool has_generate_method = has_method(LW_NAME(_generate_name));
 		ERR_FAIL_COND_V_MSG(has_generate_method && !task_script->is_tool(), _generate_name(), vformat("BTTask: @tool annotation is required if _generate_name is defined: %s", task_script->get_path()));
 		if (task_script->is_tool() && has_generate_method) {

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1219,7 +1219,7 @@ void LimboAIEditor::_update_favorite_tasks() {
 		String task_meta = favorite_tasks[i];
 
 		if (task_meta.is_empty() || (!FILE_EXISTS(task_meta) && !ClassDB::class_exists(task_meta))) {
-			call_deferred(LW_NAME(_update_banners));
+			callable_mp(this, &LimboAIEditor::_update_banners).call_deferred();
 			continue;
 		}
 

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -37,7 +37,6 @@
 #include "editor/editor_interface.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
-#include "editor/editor_undo_redo_manager.h"
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/inspector_dock.h"
@@ -58,7 +57,6 @@
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_paths.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
-#include <godot_cpp/classes/editor_undo_redo_manager.hpp>
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/file_system_dock.hpp>
 #include <godot_cpp/classes/input.hpp>
@@ -82,14 +80,25 @@ _FORCE_INLINE_ String _get_script_template_path() {
 	return templates_search_path.path_join("BTTask").path_join("custom_task.gd");
 }
 
+EditorUndoRedoManager *LimboAIEditor::_new_undo_redo_action(const String &p_name, UndoRedo::MergeMode p_mode) {
+#ifdef LIMBOAI_MODULE
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+#elif LIMBOAI_GDEXTENSION
+	EditorUndoRedoManager *undo_redo = plugin->get_undo_redo();
+#endif
+	// ! HACK: Force global history to be used for resources without a set path.
+	undo_redo->create_action(p_name, p_mode, dummy_history_context);
+	undo_redo->force_fixed_history();
+	return undo_redo;
+}
+
 void LimboAIEditor::_add_task(const Ref<BTTask> &p_task, bool p_as_sibling) {
 	if (task_tree->get_bt().is_null()) {
 		return;
 	}
 	ERR_FAIL_COND(p_task.is_null());
 
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Add BT Task"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Add BT Task"));
 
 	int insert_idx = -1;
 	Ref<BTTask> selected = task_tree->get_selected();
@@ -169,8 +178,7 @@ void LimboAIEditor::_add_task_by_class_or_path(const String &p_class_or_path) {
 void LimboAIEditor::_remove_task(const Ref<BTTask> &p_task) {
 	ERR_FAIL_COND(p_task.is_null());
 	ERR_FAIL_COND(task_tree->get_bt().is_null());
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Remove BT Task"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Remove BT Task"));
 	if (p_task->get_parent() == nullptr) {
 		ERR_FAIL_COND(task_tree->get_bt()->get_root_task() != p_task);
 		undo_redo->add_do_method(task_tree->get_bt().ptr(), LW_NAME(set_root_task), Variant());
@@ -226,7 +234,7 @@ void LimboAIEditor::_disable_editing() {
 	usage_hint->show();
 }
 
-void LimboAIEditor::edit_bt(Ref<BehaviorTree> p_behavior_tree, bool p_force_refresh) {
+void LimboAIEditor::edit_bt(const Ref<BehaviorTree> &p_behavior_tree, bool p_force_refresh) {
 	ERR_FAIL_COND_MSG(p_behavior_tree.is_null(), "p_behavior_tree is null");
 
 	if (!p_force_refresh && task_tree->get_bt() == p_behavior_tree) {
@@ -327,8 +335,7 @@ void LimboAIEditor::_extract_subtree(const String &p_path) {
 	Ref<BTTask> selected = task_tree->get_selected();
 	ERR_FAIL_COND(selected.is_null());
 
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Extract Subtree"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Extract Subtree"));
 
 	Ref<BehaviorTree> bt = memnew(BehaviorTree);
 	bt->set_root_task(selected->clone());
@@ -459,7 +466,6 @@ void LimboAIEditor::_on_tree_rmb(const Vector2 &p_menu_pos) {
 }
 
 void LimboAIEditor::_action_selected(int p_id) {
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
 	switch (p_id) {
 		case ACTION_RENAME: {
 			if (!task_tree->get_selected().is_valid()) {
@@ -537,7 +543,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 				Ref<BTTask> parent = sel->get_parent();
 				int idx = sel->get_index();
 				if (idx > 0 && idx < parent->get_child_count()) {
-					undo_redo->create_action(TTR("Move BT Task"));
+					EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Move BT Task"));
 					undo_redo->add_do_method(parent.ptr(), LW_NAME(remove_child), sel);
 					undo_redo->add_do_method(parent.ptr(), LW_NAME(add_child_at_index), sel, idx - 1);
 					undo_redo->add_undo_method(parent.ptr(), LW_NAME(remove_child), sel);
@@ -555,7 +561,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 				Ref<BTTask> parent = sel->get_parent();
 				int idx = sel->get_index();
 				if (idx >= 0 && idx < (parent->get_child_count() - 1)) {
-					undo_redo->create_action(TTR("Move BT Task"));
+					EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Move BT Task"));
 					undo_redo->add_do_method(parent.ptr(), LW_NAME(remove_child), sel);
 					undo_redo->add_do_method(parent.ptr(), LW_NAME(add_child_at_index), sel, idx + 1);
 					undo_redo->add_undo_method(parent.ptr(), LW_NAME(remove_child), sel);
@@ -570,7 +576,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 		case ACTION_DUPLICATE: {
 			Ref<BTTask> sel = task_tree->get_selected();
 			if (sel.is_valid()) {
-				undo_redo->create_action(TTR("Duplicate BT Task"));
+				EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Duplicate BT Task"));
 				Ref<BTTask> parent = sel->get_parent();
 				if (parent.is_null()) {
 					parent = sel;
@@ -589,7 +595,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 			if (sel.is_valid() && task_tree->get_bt()->get_root_task() != sel) {
 				Ref<BTTask> parent = sel->get_parent();
 				ERR_FAIL_COND(parent.is_null());
-				undo_redo->create_action(TTR("Make Root"));
+				EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Make Root"));
 				undo_redo->add_do_method(parent.ptr(), LW_NAME(remove_child), sel);
 				Ref<BTTask> old_root = task_tree->get_bt()->get_root_task();
 				undo_redo->add_do_method(task_tree->get_bt().ptr(), LW_NAME(set_root_task), sel);
@@ -616,8 +622,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 				if (p_id == ACTION_CUT) {
 					clipboard_task = sel->clone();
 				}
-
-				undo_redo->create_action(TTR("Remove BT Task"));
+				EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Remove BT Task"));
 				if (sel->is_root()) {
 					undo_redo->add_do_method(task_tree->get_bt().ptr(), LW_NAME(set_root_task), Variant());
 					undo_redo->add_undo_method(task_tree->get_bt().ptr(), LW_NAME(set_root_task), task_tree->get_bt()->get_root_task());
@@ -848,8 +853,7 @@ void LimboAIEditor::_on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, 
 		return;
 	}
 
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Drag BT Task"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Drag BT Task"));
 	undo_redo->add_do_method(p_task->get_parent().ptr(), LW_NAME(remove_child), p_task);
 
 	if (p_type == 0) {
@@ -943,8 +947,7 @@ void LimboAIEditor::_task_type_selected(const String &p_class_or_path) {
 	Ref<BTTask> new_task = _create_task_by_class_or_path(p_class_or_path);
 	ERR_FAIL_COND_MSG(new_task.is_null(), "LimboAI: Unable to construct task.");
 
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Change BT task type"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Change BT task type"));
 	undo_redo->add_do_method(this, LW_NAME(_replace_task), selected_task, new_task);
 	undo_redo->add_undo_method(this, LW_NAME(_replace_task), new_task, selected_task);
 	undo_redo->add_do_method(task_tree, LW_NAME(update_tree));
@@ -1198,8 +1201,7 @@ void LimboAIEditor::_rename_task_confirmed() {
 	ERR_FAIL_COND(!task_tree->get_selected().is_valid());
 	rename_dialog->hide();
 
-	EditorUndoRedoManager *undo_redo = GET_UNDO_REDO();
-	undo_redo->create_action(TTR("Set Custom Name"));
+	EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Set Custom Name"));
 	undo_redo->add_do_method(task_tree->get_selected().ptr(), LW_NAME(set_custom_name), rename_edit->get_text());
 	undo_redo->add_undo_method(task_tree->get_selected().ptr(), LW_NAME(set_custom_name), task_tree->get_selected()->get_custom_name());
 	undo_redo->add_do_method(task_tree, LW_NAME(update_task), task_tree->get_selected());
@@ -1462,6 +1464,7 @@ void LimboAIEditor::_bind_methods() {
 LimboAIEditor::LimboAIEditor() {
 	plugin = nullptr;
 	idx_history = 0;
+	dummy_history_context = memnew(Object);
 
 	EDITOR_DEF("limbo_ai/editor/prefer_online_documentation", false);
 
@@ -1795,6 +1798,7 @@ LimboAIEditor::LimboAIEditor() {
 }
 
 LimboAIEditor::~LimboAIEditor() {
+	memdelete(dummy_history_context);
 }
 
 //**** LimboAIEditor ^

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -26,6 +26,7 @@
 #include "core/object/object.h"
 #include "core/templates/hash_set.h"
 #include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
@@ -42,9 +43,6 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/texture.h"
-
-#define GET_UNDO_REDO() EditorUndoRedoManager::get_singleton()
-
 #endif // LIMBOAI_MODULE
 
 #ifdef LIMBOAI_GDEXTENSION
@@ -52,6 +50,7 @@
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/editor_spin_slider.hpp>
+#include <godot_cpp/classes/editor_undo_redo_manager.hpp>
 #include <godot_cpp/classes/file_dialog.hpp>
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/h_split_container.hpp>
@@ -66,8 +65,6 @@
 #include <godot_cpp/variant/variant.hpp>
 
 using namespace godot;
-
-#define GET_UNDO_REDO() plugin->get_undo_redo()
 
 #endif // LIMBOAI_GDEXTENSION
 
@@ -189,6 +186,10 @@ private:
 
 	AcceptDialog *info_dialog;
 
+	// ! HACK: Force global history to be used for resources without a set path.
+	Object *dummy_history_context = nullptr;
+	EditorUndoRedoManager *_new_undo_redo_action(const String &p_name = "", UndoRedo::MergeMode p_mode = UndoRedo::MERGE_DISABLE);
+
 	void _add_task(const Ref<BTTask> &p_task, bool p_as_sibling);
 	void _add_task_with_prototype(const Ref<BTTask> &p_prototype);
 	Ref<BTTask> _create_task_by_class_or_path(const String &p_class_or_path) const;
@@ -258,7 +259,7 @@ protected:
 
 public:
 	void set_plugin(EditorPlugin *p_plugin) { plugin = p_plugin; };
-	void edit_bt(Ref<BehaviorTree> p_behavior_tree, bool p_force_refresh = false);
+	void edit_bt(const Ref<BehaviorTree> &p_behavior_tree, bool p_force_refresh = false);
 	Ref<BlackboardPlan> get_edited_blackboard_plan();
 
 	void apply_changes();

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -189,6 +189,7 @@ private:
 	// ! HACK: Force global history to be used for resources without a set path.
 	Object *dummy_history_context = nullptr;
 	EditorUndoRedoManager *_new_undo_redo_action(const String &p_name = "", UndoRedo::MergeMode p_mode = UndoRedo::MERGE_DISABLE);
+	void _commit_action_with_update(EditorUndoRedoManager *p_undo_redo);
 
 	void _add_task(const Ref<BTTask> &p_task, bool p_as_sibling);
 	void _add_task_with_prototype(const Ref<BTTask> &p_prototype);
@@ -201,6 +202,7 @@ private:
 	void _new_bt();
 	void _save_bt(String p_path);
 	void _load_bt(String p_path);
+	void _update_task_tree(const Ref<BehaviorTree> &p_bt, const Ref<BTTask> &p_specific_task = nullptr);
 	void _disable_editing();
 	void _mark_as_dirty(bool p_dirty);
 	void _create_user_task_dir();

--- a/editor/task_palette.cpp
+++ b/editor/task_palette.cpp
@@ -420,7 +420,7 @@ void TaskPalette::_category_item_toggled(bool p_pressed, const String &p_categor
 }
 
 void TaskPalette::_filter_data_changed() {
-	call_deferred(LW_NAME(refresh));
+	callable_mp(this, &TaskPalette::refresh).call_deferred();
 	_update_filter_button();
 }
 

--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -60,7 +60,7 @@ void LimboHSM::change_active_state(LimboState *p_state) {
 	active_state->_enter();
 	active_state->set_process_input(true);
 
-	emit_signal(LimboStringNames::get_singleton()->active_state_changed, active_state, previous_active);
+	emit_signal(LW_NAME(active_state_changed), active_state, previous_active);
 }
 
 void LimboHSM::_enter() {

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -63,7 +63,7 @@ LimboState *LimboState::named(const String &p_name) {
 void LimboState::_enter() {
 	active = true;
 	GDVIRTUAL_CALL(_enter);
-	emit_signal(LimboStringNames::get_singleton()->entered);
+	emit_signal(LW_NAME(entered));
 }
 
 void LimboState::_exit() {
@@ -71,18 +71,18 @@ void LimboState::_exit() {
 		return;
 	}
 	GDVIRTUAL_CALL(_exit);
-	emit_signal(LimboStringNames::get_singleton()->exited);
+	emit_signal(LW_NAME(exited));
 	active = false;
 }
 
 void LimboState::_update(double p_delta) {
 	GDVIRTUAL_CALL(_update, p_delta);
-	emit_signal(LimboStringNames::get_singleton()->updated, p_delta);
+	emit_signal(LW_NAME(updated), p_delta);
 }
 
 void LimboState::_setup() {
 	GDVIRTUAL_CALL(_setup);
-	emit_signal(LimboStringNames::get_singleton()->setup);
+	emit_signal(LW_NAME(setup));
 }
 
 void LimboState::_initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard) {
@@ -154,19 +154,19 @@ bool LimboState::dispatch(const StringName &p_event, const Variant &p_cargo) {
 
 LimboState *LimboState::call_on_enter(const Callable &p_callable) {
 	ERR_FAIL_COND_V(!p_callable.is_valid(), this);
-	connect(LimboStringNames::get_singleton()->entered, p_callable);
+	connect(LW_NAME(entered), p_callable);
 	return this;
 }
 
 LimboState *LimboState::call_on_exit(const Callable &p_callable) {
 	ERR_FAIL_COND_V(!p_callable.is_valid(), this);
-	connect(LimboStringNames::get_singleton()->exited, p_callable);
+	connect(LW_NAME(exited), p_callable);
 	return this;
 }
 
 LimboState *LimboState::call_on_update(const Callable &p_callable) {
 	ERR_FAIL_COND_V(!p_callable.is_valid(), this);
-	connect(LimboStringNames::get_singleton()->updated, p_callable);
+	connect(LW_NAME(updated), p_callable);
 	return this;
 }
 

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -27,14 +27,8 @@
 LimboStringNames *LimboStringNames::singleton = nullptr;
 
 LimboStringNames::LimboStringNames() {
-	_enter = SN("_enter");
-	_exit = SN("_exit");
 	_generate_name = SN("_generate_name");
-	_get_configuration_warnings = SN("_get_configuration_warnings");
 	_replace_task = SN("_replace_task");
-	_setup = SN("_setup");
-	_tick = SN("_tick");
-	_update_banners = SN("_update_banners");
 	_update_task_tree = SN("_update_task_tree");
 	_weight_ = SN("_weight_");
 	accent_color = SN("accent_color");
@@ -46,19 +40,12 @@ LimboStringNames::LimboStringNames() {
 	add_child = SN("add_child");
 	add_child_at_index = SN("add_child_at_index");
 	AnimationFilter = SN("AnimationFilter");
-	Back = SN("Back");
-	behavior_tree = SN("behavior_tree");
 	behavior_tree_finished = SN("behavior_tree_finished");
-	BehaviorTree = SN("BehaviorTree");
 	bold = SN("bold");
-	BTAlwaysFail = SN("BTAlwaysFail");
-	BTAlwaysSucceed = SN("BTAlwaysSucceed");
 	button_down = SN("button_down");
 	button_up = SN("button_up");
 	call_deferred = SN("call_deferred");
 	changed = SN("changed");
-	connect = SN("connect");
-	dark_color_1 = SN("dark_color_1");
 	dark_color_2 = SN("dark_color_2");
 	Debug = SN("Debug");
 	disabled_font_color = SN("disabled_font_color");
@@ -71,7 +58,6 @@ LimboStringNames::LimboStringNames() {
 	EditorFonts = SN("EditorFonts");
 	EditorIcons = SN("EditorIcons");
 	EditorStyles = SN("EditorStyles");
-	emit_changed = SN("emit_changed");
 	entered = SN("entered");
 	error_value = SN("error_value");
 	EVENT_FAILURE = SN("failure");
@@ -84,7 +70,6 @@ LimboStringNames::LimboStringNames() {
 	font = SN("font");
 	font_color = SN("font_color");
 	font_size = SN("font_size");
-	Forward = SN("Forward");
 	freed = SN("freed");
 	gui_input = SN("gui_input");
 	GuiOptionArrow = SN("GuiOptionArrow");
@@ -97,10 +82,6 @@ LimboStringNames::LimboStringNames() {
 	Info = SN("Info");
 	item_collapsed = SN("item_collapsed");
 	item_selected = SN("item_selected");
-	LimboDeselectAll = SN("LimboDeselectAll");
-	LimboExtraClock = SN("LimboExtraClock");
-	LimboPercent = SN("LimboPercent");
-	LimboSelectAll = SN("LimboSelectAll");
 	LimboVarAdd = SN("LimboVarAdd");
 	LimboVarEmpty = SN("LimboVarEmpty");
 	LimboVarError = SN("LimboVarError");
@@ -125,7 +106,6 @@ LimboStringNames::LimboStringNames() {
 	popup_hide = SN("popup_hide");
 	pressed = SN("pressed");
 	probability_clicked = SN("probability_clicked");
-	refresh = SN("refresh");
 	Reload = SN("Reload");
 	Remove = SN("Remove");
 	remove_child = SN("remove_child");

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -34,8 +34,8 @@ LimboStringNames::LimboStringNames() {
 	_replace_task = SN("_replace_task");
 	_setup = SN("_setup");
 	_tick = SN("_tick");
-	_update = SN("_update");
 	_update_banners = SN("_update_banners");
+	_update_task_tree = SN("_update_task_tree");
 	_weight_ = SN("_weight_");
 	accent_color = SN("accent_color");
 	ActionCopy = SN("ActionCopy");
@@ -158,8 +158,6 @@ LimboStringNames::LimboStringNames() {
 	Tree = SN("Tree");
 	TripleBar = SN("TripleBar");
 	update_mode = SN("update_mode");
-	update_task = SN("update_task");
-	update_tree = SN("update_tree");
 	updated = SN("updated");
 	visibility_changed = SN("visibility_changed");
 	window_visibility_changed = SN("window_visibility_changed");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -43,14 +43,8 @@ class LimboStringNames {
 public:
 	_FORCE_INLINE_ static LimboStringNames *get_singleton() { return singleton; }
 
-	StringName _enter;
-	StringName _exit;
 	StringName _generate_name;
-	StringName _get_configuration_warnings;
 	StringName _replace_task;
-	StringName _setup;
-	StringName _tick;
-	StringName _update_banners;
 	StringName _update_task_tree;
 	StringName _weight_;
 	StringName accent_color;
@@ -62,19 +56,12 @@ public:
 	StringName add_child;
 	StringName Add;
 	StringName AnimationFilter;
-	StringName Back;
 	StringName behavior_tree_finished;
-	StringName behavior_tree;
-	StringName BehaviorTree;
 	StringName bold;
-	StringName BTAlwaysFail;
-	StringName BTAlwaysSucceed;
 	StringName button_down;
 	StringName button_up;
 	StringName call_deferred;
 	StringName changed;
-	StringName connect;
-	StringName dark_color_1;
 	StringName dark_color_2;
 	StringName Debug;
 	StringName disabled_font_color;
@@ -87,7 +74,6 @@ public:
 	StringName EditorFonts;
 	StringName EditorIcons;
 	StringName EditorStyles;
-	StringName emit_changed;
 	StringName entered;
 	StringName error_value;
 	StringName EVENT_FAILURE;
@@ -100,7 +86,6 @@ public:
 	StringName font_color;
 	StringName font_size;
 	StringName font;
-	StringName Forward;
 	StringName freed;
 	StringName gui_input;
 	StringName GuiOptionArrow;
@@ -113,11 +98,6 @@ public:
 	StringName Info;
 	StringName item_collapsed;
 	StringName item_selected;
-	StringName LimboDeselectAll;
-	StringName LimboExtraClock;
-	StringName LimboExtractSubtree;
-	StringName LimboPercent;
-	StringName LimboSelectAll;
 	StringName LimboVarAdd;
 	StringName LimboVarEmpty;
 	StringName LimboVarError;
@@ -142,7 +122,6 @@ public:
 	StringName popup_hide;
 	StringName pressed;
 	StringName probability_clicked;
-	StringName refresh;
 	StringName Reload;
 	StringName remove_child;
 	StringName Remove;

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -51,7 +51,7 @@ public:
 	StringName _setup;
 	StringName _tick;
 	StringName _update_banners;
-	StringName _update;
+	StringName _update_task_tree;
 	StringName _weight_;
 	StringName accent_color;
 	StringName ActionCopy;
@@ -175,8 +175,6 @@ public:
 	StringName Tree;
 	StringName TripleBar;
 	StringName update_mode;
-	StringName update_task;
-	StringName update_tree;
 	StringName updated;
 	StringName visibility_changed;
 	StringName window_visibility_changed;


### PR DESCRIPTION
Solves #37, but it's not an ideal solution.