### PR TITLE
Generalize EDITOR_DEF macro to fix potential editor setting issues

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1470,11 +1470,6 @@ LimboAIEditor::LimboAIEditor() {
 	pinfo.hint = PROPERTY_HINT_ENUM;
 	pinfo.hint_string = "Classic:0,Widescreen Optimized:1";
 	EDITOR_SETTINGS()->add_property_info(pinfo);
-
-	// Hotfix: Ensure the property is set (EditorInterface->get_singleton()->set_initial_value(m_setting, m_value, false) appears insufficient.)
-    if (!EDITOR_SETTINGS()->has_setting("limbo_ai/editor/layout")) {
-        EDITOR_SETTINGS()->set_setting("limbo_ai/editor/layout", 0);
-    }
 #endif
 
 	LW_SHORTCUT("limbo_ai/rename_task", TTR("Rename"), LW_KEY(F2));

--- a/util/limbo_compat.h
+++ b/util/limbo_compat.h
@@ -114,7 +114,12 @@ using namespace godot;
 #define ADD_STYLEBOX_OVERRIDE(m_control, m_name, m_stylebox) (m_control->add_theme_stylebox_override(m_name, m_stylebox))
 #define GET_NODE(m_parent, m_path) m_parent->get_node_internal(m_path)
 #define OBJECT_DB_GET_INSTANCE(m_id) ObjectDB::get_instance(m_id)
-#define EDITOR_DEF(m_setting, m_value) EditorInterface::get_singleton()->get_editor_settings()->set_initial_value(m_setting, m_value, false)
+#define EDITOR_DEF(m_setting, m_value) do {	/* do-while(0) ideom to avoid any potential semicolon errors. */\
+	EditorInterface::get_singleton()->get_editor_settings()->set_initial_value(m_setting, m_value, false); 	\
+		if (!EDITOR_SETTINGS()->has_setting(m_setting)) {                                                  	\
+			EDITOR_SETTINGS()->set_setting(m_setting, m_value);                                            	\
+		}                                                                                                  	\
+	} while(0)
 
 _FORCE_INLINE_ bool OBJECT_HAS_PROPERTY(Object *p_obj, const StringName &p_prop) {
 	return Variant(p_obj).has_key(p_prop);


### PR DESCRIPTION
This commit provides a generalized solution to ensure editor settings are properly initialized and available in both module and GDExtension versions. While #204 fixed the specific issue with 'limbo_ai/editor/layout', this change aims to prevent similar problems for all editor settings.

In particular, `limbo_ai/editor/prefer_online_documentation` was also not available.

Changes:
- Updated EDITOR_DEF macro to handle both module and GDExtension cases
- Remove special case for `limbo_ai/editor/layout` in LimboAiEditorPlugin from earlier fix.