### PR TITLE
Implement task multiple selection and drag and drop

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -809,7 +809,7 @@ void LimboAIEditor::_on_visibility_changed() {
 }
 
 void LimboAIEditor::_on_header_pressed() {
-	task_tree->deselect();
+	task_tree->clear_selection();
 #ifdef LIMBOAI_MODULE
 	if (task_tree->get_bt().is_valid()) {
 		task_tree->get_bt()->editor_set_section_unfold("blackboard_plan", true);
@@ -913,7 +913,7 @@ void LimboAIEditor::_on_tasks_dragged(const TypedArray<BTTask> &p_tasks, Ref<BTT
 			}
 		}
 
-		undo_redo->add_undo_method(task->get_parent().ptr(), "add_child_at_index", task, task->get_index());
+		undo_redo->add_undo_method(task->get_parent().ptr(), LW_NAME(add_child_at_index), task, task->get_index());
 		++drop_idx;
 	}
 

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -239,7 +239,7 @@ private:
 	void _on_save_pressed();
 	void _on_history_back();
 	void _on_history_forward();
-	void _on_task_dragged(Ref<BTTask> p_task, Ref<BTTask> p_to_task, int p_type);
+	void _on_tasks_dragged(const TypedArray<BTTask> &p_tasks, Ref<BTTask> p_to_task, int p_to_pos);
 	void _on_resources_reload(const PackedStringArray &p_resources);
 	void _on_filesystem_changed();
 	void _on_new_script_pressed();

--- a/editor/task_tree.h
+++ b/editor/task_tree.h
@@ -90,8 +90,11 @@ public:
 	Ref<BehaviorTree> get_bt() const { return bt; }
 	void update_tree() { _update_tree(); }
 	void update_task(const Ref<BTTask> &p_task);
+	void add_selection(const Ref<BTTask> &p_task);
+	void remove_selection(const Ref<BTTask> &p_task);
 	Ref<BTTask> get_selected() const;
-	void deselect();
+	Vector<Ref<BTTask>> get_selected_tasks() const;
+	void clear_selection();
 
 	Rect2 get_selected_probability_rect() const;
 	double get_selected_probability_weight() const;

--- a/editor/task_tree.h
+++ b/editor/task_tree.h
@@ -75,6 +75,7 @@ private:
 	Variant _get_drag_data_fw(const Point2 &p_point);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data) const;
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data);
+	void _normalize_drop(TreeItem *item, int type, int &to_pos, Ref<BTTask> &to_task) const;
 
 	void _draw_probability(Object *item_obj, Rect2 rect);
 

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -78,6 +78,7 @@ LimboStringNames::LimboStringNames() {
 	HeaderSmall = SN("HeaderSmall");
 	Help = SN("Help");
 	icon_max_width = SN("icon_max_width");
+	class_icon_size = SN("class_icon_size");
 	id_pressed = SN("id_pressed");
 	Info = SN("Info");
 	item_collapsed = SN("item_collapsed");

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -127,7 +127,7 @@ LimboStringNames::LimboStringNames() {
 	task_activated = SN("task_activated");
 	task_button_pressed = SN("task_button_pressed");
 	task_button_rmb = SN("task_button_rmb");
-	task_dragged = SN("task_dragged");
+	tasks_dragged = SN("tasks_dragged");
 	task_meta = SN("task_meta");
 	task_selected = SN("task_selected");
 	text_changed = SN("text_changed");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -143,7 +143,7 @@ public:
 	StringName task_activated;
 	StringName task_button_pressed;
 	StringName task_button_rmb;
-	StringName task_dragged;
+	StringName tasks_dragged;
 	StringName task_meta;
 	StringName task_selected;
 	StringName text_changed;

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -94,6 +94,7 @@ public:
 	StringName HeaderSmall;
 	StringName Help;
 	StringName icon_max_width;
+	StringName class_icon_size;
 	StringName id_pressed;
 	StringName Info;
 	StringName item_collapsed;


### PR DESCRIPTION
This adds multiple selection support to the task tree editor.

I implemented it to behavior similar to the scene tree editor. The major difference is that only the latest select task can be edited in the inspector since Godot doesn't have multiple resource editing like there is for nodes.

![multi_drag_and_drop](https://github.com/user-attachments/assets/66afe604-bb28-4d1c-b414-b820b8c45ae0)

