### PR TITLE
Remember loaded `BehaviorTree`s of last session

### DIFF
--- a/editor/debugger/limbo_debugger_plugin.cpp
+++ b/editor/debugger/limbo_debugger_plugin.cpp
@@ -193,18 +193,18 @@ void LimboDebuggerTab::_notification(int p_what) {
 
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			String conf_path = PROJECT_CONFIG_FILE();
+			String conf_path = LAYOUT_CONFIG_FILE();
 			if (cf->load(conf_path) == OK) {
-				Variant value = cf->get_value("debugger", "update_interval_msec", 0);
+				Variant value = cf->get_value("LimboAI", "debugger_update_interval_msec", 0);
 				update_interval->set_value(value);
 			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			String conf_path = PROJECT_CONFIG_FILE();
+			String conf_path = LAYOUT_CONFIG_FILE();
 			cf->load(conf_path);
-			cf->set_value("debugger", "update_interval_msec", update_interval->get_value());
+			cf->set_value("LimboAI", "debugger_update_interval_msec", update_interval->get_value());
 			cf->save(conf_path);
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -63,6 +63,7 @@
 #include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/variant.hpp>
+#include <godot_cpp/classes/config_file.hpp>
 
 using namespace godot;
 
@@ -263,6 +264,8 @@ public:
 	void set_plugin(EditorPlugin *p_plugin) { plugin = p_plugin; };
 	void edit_bt(const Ref<BehaviorTree> &p_behavior_tree, bool p_force_refresh = false);
 	Ref<BlackboardPlan> get_edited_blackboard_plan();
+	void set_window_layout(const Ref<ConfigFile> &p_configuration);
+	void get_window_layout(const Ref<ConfigFile> &p_configuration);
 
 	void apply_changes();
 
@@ -293,6 +296,8 @@ public:
 	virtual void apply_changes() override;
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
+	virtual void set_window_layout(Ref<ConfigFile> p_configuration) override;
+	virtual void get_window_layout(Ref<ConfigFile> p_configuration) override;
 
 #elif LIMBOAI_GDEXTENSION
 	bool _has_main_screen() const override { return true; }
@@ -303,6 +308,8 @@ public:
 	virtual void _edit(Object *p_object) override;
 	virtual bool _handles(Object *p_object) const override;
 	virtual Ref<Texture2D> _get_plugin_icon() const override;
+	virtual void _set_window_layout(const Ref<ConfigFile> &p_configuration) override;
+	virtual void _get_window_layout(const Ref<ConfigFile> &p_configuration) override;
 #endif // LIMBOAI_MODULE & LIMBOAI_GDEXTENSION
 
 	LimboAIEditorPlugin();

--- a/editor/task_palette.cpp
+++ b/editor/task_palette.cpp
@@ -440,9 +440,9 @@ void TaskPalette::refresh() {
 		// Restore collapsed state from config.
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		String conf_path = PROJECT_CONFIG_FILE();
+		String conf_path = LAYOUT_CONFIG_FILE();
 		if (cf->load(conf_path) == OK) {
-			Variant value = cf->get_value("task_palette", "collapsed_sections", Array());
+			Variant value = cf->get_value("LimboAI", "task_palette_collapsed_sections", Array());
 			if (VARIANT_IS_ARRAY(value)) {
 				Array arr = value;
 				for (int i = 0; i < arr.size(); i++) {
@@ -547,19 +547,19 @@ void TaskPalette::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			String conf_path = PROJECT_CONFIG_FILE();
+			String conf_path = LAYOUT_CONFIG_FILE();
 			if (cf->load(conf_path) == OK) {
-				Variant value = cf->get_value("task_palette", "type_filter", FilterSettings::TypeFilter(0));
+				Variant value = cf->get_value("LimboAI", "task_palette_type_filter", FilterSettings::TypeFilter(0));
 				if (VARIANT_IS_NUM(value)) {
 					filter_settings.type_filter = (FilterSettings::TypeFilter)(int)value;
 				}
 
-				value = cf->get_value("task_palette", "category_filter", FilterSettings::CategoryFilter(0));
+				value = cf->get_value("LimboAI", "task_palette_category_filter", FilterSettings::CategoryFilter(0));
 				if (VARIANT_IS_NUM(value)) {
 					filter_settings.category_filter = (FilterSettings::CategoryFilter)(int)value;
 				}
 
-				value = cf->get_value("task_palette", "excluded_categories", Array());
+				value = cf->get_value("LimboAI", "task_palette_excluded_categories", Array());
 				if (VARIANT_IS_ARRAY(value)) {
 					Array arr = value;
 					for (int i = 0; i < arr.size(); i++) {
@@ -574,7 +574,7 @@ void TaskPalette::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			String conf_path = PROJECT_CONFIG_FILE();
+			String conf_path = LAYOUT_CONFIG_FILE();
 			cf->load(conf_path);
 
 			Array collapsed_sections;
@@ -584,16 +584,16 @@ void TaskPalette::_notification(int p_what) {
 					collapsed_sections.push_back(sec->get_category_name());
 				}
 			}
-			cf->set_value("task_palette", "collapsed_sections", collapsed_sections);
+			cf->set_value("LimboAI", "task_palette_collapsed_sections", collapsed_sections);
 
-			cf->set_value("task_palette", "type_filter", filter_settings.type_filter);
-			cf->set_value("task_palette", "category_filter", filter_settings.category_filter);
+			cf->set_value("LimboAI", "task_palette_type_filter", filter_settings.type_filter);
+			cf->set_value("LimboAI", "task_palette_category_filter", filter_settings.category_filter);
 
 			Array excluded_categories;
 			for (const String &cat : filter_settings.excluded_categories) {
 				excluded_categories.append(cat);
 			}
-			cf->set_value("task_palette", "excluded_categories", excluded_categories);
+			cf->set_value("LimboAI", "task_palette_excluded_categories", excluded_categories);
 
 			cf->save(conf_path);
 		} break;

--- a/util/limbo_compat.h
+++ b/util/limbo_compat.h
@@ -170,7 +170,7 @@ inline void VARIANT_DELETE_IF_OBJECT(Variant m_variant) {
 
 Variant VARIANT_DEFAULT(Variant::Type p_type);
 
-#define PROJECT_CONFIG_FILE() GET_PROJECT_SETTINGS_DIR().path_join("limbo_ai.cfg")
+#define LAYOUT_CONFIG_FILE() GET_PROJECT_SETTINGS_DIR().path_join("editor_layout.cfg")
 #define IS_RESOURCE_FILE(m_path) (m_path.begins_with("res://") && m_path.find("::") == -1)
 #define RESOURCE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, m_type)
 #define RESOURCE_IS_BUILT_IN(m_res) (m_res->get_path().is_empty() || m_res->get_path().contains("::"))


### PR DESCRIPTION
Remember which trees were edited when the editor closed and move all editor data to the default configuration file.

Closes: https://github.com/limbonaut/limboai/issues/221