### PR TITLE
Fix invalid access errors on exit in LimboHSM

### DIFF
--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -263,6 +263,21 @@ void LimboHSM::_validate_property(PropertyInfo &p_property) const {
 void LimboHSM::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
+			if (was_active && is_root()) {
+				// Re-activate the root HSM if it was previously active.
+				// Typically, this happens when the node is re-entered scene repeatedly (e.g., re-parenting, pooling).
+				set_active(true);
+			}
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (is_root()) {
+				// Remember active status for re-parenting and exit state machine
+				// to release resources and signal connections if active.
+				was_active = active;
+				if (is_active()) {
+					_exit();
+				}
+			}
 		} break;
 		case NOTIFICATION_PROCESS: {
 			_update(get_process_delta_time());

--- a/hsm/limbo_hsm.h
+++ b/hsm/limbo_hsm.h
@@ -55,6 +55,7 @@ private:
 	LimboState *previous_active;
 	LimboState *next_active;
 	bool updating = false;
+	bool was_active = false;
 
 	HashMap<TransitionKey, Transition, TransitionKeyHasher> transitions;
 

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -190,11 +190,6 @@ void LimboState::_notification(int p_what) {
 				_update_blackboard_plan();
 			}
 		} break;
-		case NOTIFICATION_PREDELETE: {
-			if (is_active()) {
-				_exit();
-			}
-		} break;
 	}
 }
 


### PR DESCRIPTION
Since #131, `LimboState::_exit()` became a source of potential ~~crashes~~ errors if object references are used without a validity check. It's too easy to miss this, which can lead to _exit() throwing errors at runtime and not finishing executing.

This fix reverts #131 change and proposes alternative approach of re-activating root HSM upon tree entering if it was previously active. Note that it's not an ideal solution, as some state will be lost upon re-parenting: HSM exits and then re-activates and enters its initial state.