### PR TITLE
Call both native and script `_setup/_enter/_exit` in BTTask

### DIFF
--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -172,9 +172,8 @@ void BTTask::initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard, Node
 		get_child(i)->initialize(p_agent, p_blackboard, p_scene_root);
 	}
 
-	if (!GDVIRTUAL_CALL(_setup)) {
-		_setup();
-	}
+	_setup();
+	GDVIRTUAL_CALL(_setup);
 }
 
 Ref<BTTask> BTTask::clone() const {

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -234,9 +234,9 @@ BT::Status BTTask::execute(double p_delta) {
 				data.children.get(i)->abort();
 			}
 		}
-		if (!GDVIRTUAL_CALL(_enter)) {
-			_enter();
-		}
+		// First native, then script.
+		_enter();
+		GDVIRTUAL_CALL(_enter);
 	} else {
 		data.elapsed += p_delta;
 	}
@@ -246,9 +246,9 @@ BT::Status BTTask::execute(double p_delta) {
 	}
 
 	if (data.status != RUNNING) {
-		if (!GDVIRTUAL_CALL(_exit)) {
-			_exit();
-		}
+		// First script, then native.
+		GDVIRTUAL_CALL(_exit);
+		_exit();
 		data.elapsed = 0.0;
 	}
 	return data.status;
@@ -259,9 +259,9 @@ void BTTask::abort() {
 		get_child(i)->abort();
 	}
 	if (data.status == RUNNING) {
-		if (!GDVIRTUAL_CALL(_exit)) {
-			_exit();
-		}
+		// First script, then native.
+		GDVIRTUAL_CALL(_exit);
+		_exit();
 	}
 	data.status = FRESH;
 	data.elapsed = 0.0;


### PR DESCRIPTION
Current behavior is overriding, which is not correct, as these functions are more like "extension" than "override".