### PR TITLE
Implement Tree Search Functionality with Highlighting and Filtering

### DIFF
--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -20,6 +20,7 @@
 #include "owner_picker.h"
 #include "task_palette.h"
 #include "task_tree.h"
+#include "tree_search.h"
 
 #ifdef LIMBOAI_MODULE
 #include "core/object/class_db.h"
@@ -47,6 +48,7 @@
 
 #ifdef LIMBOAI_GDEXTENSION
 #include "godot_cpp/classes/accept_dialog.hpp"
+#include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include <godot_cpp/classes/editor_spin_slider.hpp>
@@ -63,7 +65,6 @@
 #include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/variant.hpp>
-#include <godot_cpp/classes/config_file.hpp>
 
 using namespace godot;
 
@@ -100,6 +101,7 @@ private:
 		MISC_LAYOUT_WIDESCREEN_OPTIMIZED,
 		MISC_PROJECT_SETTINGS,
 		MISC_CREATE_SCRIPT_TEMPLATE,
+		MISC_SEARCH_TREE
 	};
 
 	enum TabMenu {
@@ -134,12 +136,14 @@ private:
 		Ref<Texture2D> cut_icon;
 		Ref<Texture2D> copy_icon;
 		Ref<Texture2D> paste_icon;
+		Ref<Texture2D> search_icon;
 	} theme_cache;
 
 	EditorPlugin *plugin;
 	EditorLayout editor_layout;
 	Vector<Ref<BehaviorTree>> history;
 	int idx_history;
+	HashMap<Ref<BehaviorTree>, TreeSearch::SearchInfo> tab_search_context;
 	bool updating_tabs = false;
 	bool request_update_tabs = false;
 	HashSet<Ref<BehaviorTree>> dirty;

--- a/editor/task_tree.h
+++ b/editor/task_tree.h
@@ -9,9 +9,13 @@
  * =============================================================================
  */
 
+#ifndef TASK_TREE_H
+#define TASK_TREE_H
+
 #ifdef TOOLS_ENABLED
 
 #include "../bt/behavior_tree.h"
+#include "tree_search.h"
 
 #ifdef LIMBOAI_MODULE
 #include "scene/gui/control.h"
@@ -42,6 +46,9 @@ private:
 	bool editable;
 	bool updating_tree;
 	HashMap<RECT_CACHE_KEY, Rect2> probability_rect_cache;
+
+	Ref<TreeSearch> tree_search;
+	TreeSearchPanel *tree_search_panel;
 
 	struct ThemeCache {
 		Ref<Font> comment_font;
@@ -96,11 +103,15 @@ public:
 	Ref<BTTask> get_selected() const;
 	Vector<Ref<BTTask>> get_selected_tasks() const;
 	void clear_selection();
-
 	Rect2 get_selected_probability_rect() const;
 	double get_selected_probability_weight() const;
 	double get_selected_probability_percent() const;
 	bool selected_has_probability() const;
+
+	// TreeSearch API
+	void tree_search_show_and_focus();
+	TreeSearch::SearchInfo tree_search_get_search_info() const;
+	void tree_search_set_search_info(const TreeSearch::SearchInfo &p_search_info);
 
 	virtual bool editor_can_reload_from_file() { return false; }
 
@@ -109,3 +120,4 @@ public:
 };
 
 #endif // ! TOOLS_ENABLED
+#endif // ! TASK_TREE_H

--- a/editor/tree_search.cpp
+++ b/editor/tree_search.cpp
@@ -143,7 +143,7 @@ void TreeSearch::_highlight_tree_item(TreeItem *p_tree_item) {
 }
 
 // Custom draw callback for highlighting (bind the parent_draw_method to this)
-void TreeSearch::_draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable p_parent_draw_method) {
+void TreeSearch::_draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable &p_parent_draw_method) {
 	if (!p_tree_item) {
 		return;
 	}
@@ -533,42 +533,6 @@ TreeSearch::TreeSearch(TreeSearchPanel *p_search_panel) {
 
 /* ------- TreeSearchPanel ------- */
 
-void TreeSearchPanel::_initialize_controls() {
-	line_edit_search = memnew(LineEdit);
-	check_button_filter_highlight = memnew(CheckBox);
-	close_button = memnew(Button);
-	find_next_button = memnew(Button);
-	find_prev_button = memnew(Button);
-	label_filter = memnew(Label);
-
-	line_edit_search->set_placeholder(TTR("Search tree"));
-
-	close_button->set_theme_type_variation(LW_NAME(FlatButton));
-	find_next_button->set_theme_type_variation(LW_NAME(FlatButton));
-	find_prev_button->set_theme_type_variation(LW_NAME(FlatButton));
-
-	find_next_button->set_tooltip_text("Next Match");
-	find_prev_button->set_tooltip_text("Previous Match");
-
-	// Positioning and sizing
-	set_anchors_and_offsets_preset(LayoutPreset::PRESET_BOTTOM_WIDE);
-	set_v_size_flags(SIZE_SHRINK_CENTER); // Do not expand vertically
-
-	line_edit_search->set_h_size_flags(SIZE_EXPAND_FILL);
-
-	_add_spacer(0.1); // -> Otherwise the lineedits expand margin touches the left border.
-	add_child(line_edit_search);
-	add_child(find_prev_button);
-	add_child(find_next_button);
-	_add_spacer(0.25);
-
-	add_child(check_button_filter_highlight);
-	add_child(label_filter);
-
-	_add_spacer(0.25);
-	add_child(close_button);
-}
-
 void TreeSearchPanel::_add_spacer(float p_width_multiplier) {
 	Control *spacer = memnew(Control);
 	spacer->set_custom_minimum_size(Vector2(8.0 * EDSCALE * p_width_multiplier, 0.0));
@@ -612,7 +576,40 @@ void TreeSearchPanel::_bind_methods() {
 }
 
 TreeSearchPanel::TreeSearchPanel() {
-	_initialize_controls();
+	line_edit_search = memnew(LineEdit);
+	check_button_filter_highlight = memnew(CheckBox);
+	close_button = memnew(Button);
+	find_next_button = memnew(Button);
+	find_prev_button = memnew(Button);
+	label_filter = memnew(Label);
+
+	line_edit_search->set_placeholder(TTR("Search tree"));
+
+	close_button->set_theme_type_variation(LW_NAME(FlatButton));
+	find_next_button->set_theme_type_variation(LW_NAME(FlatButton));
+	find_prev_button->set_theme_type_variation(LW_NAME(FlatButton));
+
+	find_next_button->set_tooltip_text("Next Match");
+	find_prev_button->set_tooltip_text("Previous Match");
+
+	// Positioning and sizing
+	set_anchors_and_offsets_preset(LayoutPreset::PRESET_BOTTOM_WIDE);
+	set_v_size_flags(SIZE_SHRINK_CENTER); // Do not expand vertically
+
+	line_edit_search->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	_add_spacer(0.1); // -> Otherwise the lineedits expand margin touches the left border.
+	add_child(line_edit_search);
+	add_child(find_prev_button);
+	add_child(find_next_button);
+	_add_spacer(0.25);
+
+	add_child(check_button_filter_highlight);
+	add_child(label_filter);
+
+	_add_spacer(0.25);
+	add_child(close_button);
+
 	set_visible(false);
 }
 
@@ -624,9 +621,6 @@ TreeSearch::TreeSearchMode TreeSearchPanel::get_search_mode() const {
 }
 
 String TreeSearchPanel::get_text() const {
-	if (!line_edit_search) {
-		return String();
-	}
 	return line_edit_search->get_text();
 }
 

--- a/editor/tree_search.cpp
+++ b/editor/tree_search.cpp
@@ -1,0 +1,654 @@
+/**
+ * tree_search.cpp
+ * =============================================================================
+ * Copyright 2021-2024 Serhii Snitsaruk
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#ifdef TOOLS_ENABLED
+
+#include "tree_search.h"
+
+#include "../util/limbo_compat.h" // for edscale
+#include "../util/limbo_string_names.h"
+#include "../util/limbo_utility.h"
+
+#ifdef LIMBOAI_MODULE
+#include "core/math/math_funcs.h"
+#include "editor/editor_interface.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/main/viewport.h"
+#include "scene/resources/font.h"
+#include "scene/resources/style_box_flat.h"
+#endif // LIMBOAI_MODULE
+
+#ifdef LIMBOAI_GDEXTENSION
+#include <godot_cpp/classes/editor_interface.hpp> // for edge scale
+#include <godot_cpp/classes/font.hpp>
+#include <godot_cpp/classes/style_box_flat.hpp>
+#include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/core/math.hpp>
+
+#endif // LIMBOAI_GDEXTENSION
+
+#define UPPER_BOUND (1 << 15) // for substring search.
+
+/* ------- TreeSearch ------- */
+
+void TreeSearch::_clean_callable_cache() {
+	ERR_FAIL_COND(!tree_reference);
+
+	HashMap<TreeItem *, Callable> new_callable_cache;
+	new_callable_cache.reserve(callable_cache.size());
+
+	for (int i = 0; i < ordered_tree_items.size(); i++) {
+		TreeItem *cur_item = ordered_tree_items[i];
+		if (callable_cache.has(cur_item)) {
+			new_callable_cache[cur_item] = callable_cache[cur_item];
+		}
+	}
+	callable_cache = new_callable_cache;
+}
+
+void TreeSearch::_filter_tree() {
+	ERR_FAIL_COND(!tree_reference);
+	if (!tree_reference->get_root()) {
+		return;
+	}
+	if (matching_entries.is_empty()) {
+		return;
+	}
+
+	_filter_tree(tree_reference->get_root(), false);
+}
+
+void TreeSearch::_filter_tree(TreeItem *p_item, bool p_parent_matching) {
+	bool visible = (number_matches.has(p_item) && (number_matches.get(p_item) > 0)) || p_parent_matching;
+
+	p_item->set_visible(visible);
+
+	bool is_matching = _vector_has_bsearch(matching_entries, p_item);
+	for (int i = 0; i < p_item->get_child_count(); i++) {
+		_filter_tree(p_item->get_child(i), is_matching | p_parent_matching);
+	}
+}
+
+// Makes all tree items visible.
+void TreeSearch::_clear_filter() {
+	ERR_FAIL_COND(!tree_reference);
+	if (!tree_reference->get_root()) {
+		return;
+	}
+
+	Vector<TreeItem *> items = { tree_reference->get_root() };
+	for (int idx = 0; idx < items.size(); idx++) {
+		TreeItem *cur_item = items[idx];
+		cur_item->set_visible(true);
+
+		for (int i = 0; i < cur_item->get_child_count(); i++) {
+			items.push_back(cur_item->get_child(i));
+		}
+	}
+}
+
+void TreeSearch::_highlight_tree() {
+	ERR_FAIL_COND(!tree_reference);
+
+	for (HashMap<TreeItem *, int>::Iterator it = number_matches.begin(); it != number_matches.end(); ++it) {
+		TreeItem *tree_item = it->key;
+		_highlight_tree_item(tree_item);
+	}
+	tree_reference->queue_redraw();
+}
+
+void TreeSearch::_highlight_tree_item(TreeItem *p_tree_item) {
+	int num_m = number_matches.has(p_tree_item) ? number_matches.get(p_tree_item) : 0;
+
+	if (num_m == 0) {
+		return;
+	}
+
+	// Make sure to also call any draw method already defined.
+	Callable parent_draw_method;
+	if (p_tree_item->get_cell_mode(0) == TreeItem::CELL_MODE_CUSTOM) {
+		parent_draw_method = p_tree_item->get_custom_draw_callback(0);
+	}
+
+	// If the cached draw method is already applied, do nothing.
+	if (callable_cache.has(p_tree_item) && parent_draw_method == callable_cache.get(p_tree_item)) {
+		return;
+	}
+
+	Callable draw_callback = callable_mp(this, &TreeSearch::_draw_highlight_item).bind(parent_draw_method);
+	callable_cache[p_tree_item] = draw_callback;
+
+	// This is necessary because of the modularity of this implementation.
+	// Cache render properties of entry.
+	String cached_text = p_tree_item->get_text(0);
+	Ref<Texture2D> cached_icon = p_tree_item->get_icon(0);
+	int cached_max_width = p_tree_item->get_icon_max_width(0);
+
+	// This removes render properties in entry.
+	p_tree_item->set_custom_draw_callback(0, draw_callback);
+	p_tree_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
+
+	// Restore render properties.
+	p_tree_item->set_text(0, cached_text);
+	p_tree_item->set_icon(0, cached_icon);
+	p_tree_item->set_icon_max_width(0, cached_max_width);
+}
+
+// Custom draw callback for highlighting (bind the parent_draw_method to this)
+void TreeSearch::_draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable p_parent_draw_method) {
+	if (!p_tree_item) {
+		return;
+	}
+
+	// Call any parent draw methods such as for probability FIRST.
+	p_parent_draw_method.call(p_tree_item, p_rect);
+
+	// First part: outline
+	if (matching_entries.has(p_tree_item)) {
+		// Font info
+		Ref<Font> font = p_tree_item->get_custom_font(0);
+		if (font.is_null()) {
+			font = p_tree_item->get_tree()->get_theme_font(LW_NAME(font));
+		}
+		ERR_FAIL_NULL(font);
+		float font_size = p_tree_item->get_custom_font_size(0);
+		if (font_size == -1) {
+			font_size = p_tree_item->get_tree()->get_theme_font_size(LW_NAME(font));
+		}
+
+		// Substring size
+		String string_full = p_tree_item->get_text(0);
+		StringSearchIndices substring_idx = _substring_bounds(string_full, _get_search_mask());
+
+		String substring_match = string_full.substr(substring_idx.lower, substring_idx.upper - substring_idx.lower);
+		Vector2 substring_match_size = font->get_string_size(substring_match, HORIZONTAL_ALIGNMENT_LEFT, -1.f, font_size);
+
+		String substring_before = string_full.substr(0, substring_idx.lower);
+		Vector2 substring_before_size = font->get_string_size(substring_before, HORIZONTAL_ALIGNMENT_LEFT, -1.f, font_size);
+
+		// Stylebox
+		Ref<StyleBox> stylebox = p_tree_item->get_tree()->get_theme_stylebox(LW_NAME(Focus));
+		ERR_FAIL_NULL(stylebox);
+
+		// Extract separation
+		float h_sep = p_tree_item->get_tree()->get_theme_constant(LW_NAME(h_separation));
+
+		// Compose draw rect
+		const Vector2 PADDING = Vector2(4., 2.);
+		Rect2 draw_rect = p_rect;
+
+		Vector2 rect_offset = Vector2(substring_before_size.x, 0);
+		rect_offset.x += p_tree_item->get_icon_max_width(0);
+		rect_offset.x += (h_sep + 4. * EDSCALE);
+		rect_offset.y = (p_rect.size.y - substring_match_size.y) / 2; // center box vertically
+
+		draw_rect.position += rect_offset - PADDING / 2;
+		draw_rect.size = substring_match_size + PADDING;
+
+		// Draw
+		stylebox->draw(p_tree_item->get_tree()->get_canvas_item(), draw_rect);
+	}
+
+	// Second part: draw number
+	int num_mat = number_matches.has(p_tree_item) ? number_matches.get(p_tree_item) : 0;
+	if (num_mat > 0) {
+		float h_sep = p_tree_item->get_tree()->get_theme_constant(LW_NAME(h_separation));
+		Ref<Font> font = tree_reference->get_theme_font(LW_NAME(font));
+		float font_size = tree_reference->get_theme_font_size(LW_NAME(font)) * 0.75;
+
+		String num_string = String::num_int64(num_mat);
+		Vector2 string_size = font->get_string_size(num_string, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size);
+		Vector2 text_pos = p_rect.position;
+
+		text_pos.x += p_rect.size.x - string_size.x - h_sep;
+		text_pos.y += font->get_descent(font_size) + p_rect.size.y / 2.; // center vertically
+
+		font->draw_string(tree_reference->get_canvas_item(), text_pos, num_string, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size);
+	}
+}
+
+void TreeSearch::_update_matching_entries(const String &p_search_mask) {
+	Vector<TreeItem *> accum;
+	_find_matching_entries(tree_reference->get_root(), p_search_mask, accum);
+	matching_entries = accum;
+}
+
+/* Linaerizes the tree into [ordered_tree_items] like so:
+ - i1
+	- i2
+	- i3
+ - i4 ---> [i1,i2,i3,i4]
+*/
+void TreeSearch::_update_ordered_tree_items(TreeItem *p_tree_item) {
+	if (!p_tree_item) {
+		return;
+	}
+	if (p_tree_item == p_tree_item->get_tree()->get_root()) {
+		ordered_tree_items.clear();
+	}
+	// Add the current item to the list.
+	ordered_tree_items.push_back(p_tree_item);
+
+	// Recursively collect items from the first child.
+	TreeItem *child = p_tree_item->get_first_child();
+	while (child) {
+		_update_ordered_tree_items(child);
+		child = child->get_next();
+	}
+}
+
+void TreeSearch::_update_number_matches() {
+	ERR_FAIL_COND(!tree_reference);
+	number_matches.clear();
+	number_matches.reserve(ordered_tree_items.size());
+
+	TreeItem *tree_root = tree_reference->get_root();
+	if (!tree_root) {
+		return;
+	}
+	_update_number_matches(tree_root);
+}
+
+void TreeSearch::_update_number_matches(TreeItem *item) {
+	ERR_FAIL_COND(!item);
+	for (int i = 0; i < item->get_child_count(); i++) {
+		TreeItem *child = item->get_child(i);
+		_update_number_matches(child);
+	}
+	int count = _vector_has_bsearch(matching_entries, item) ? 1 : 0;
+
+	for (int i = 0; i < item->get_child_count(); i++) {
+		TreeItem *child = item->get_child(i);
+		count += number_matches.has(child) ? number_matches.get(child) : 0;
+	}
+	if (count == 0) {
+		return;
+	}
+
+	number_matches[item] = count;
+}
+
+String TreeSearch::_get_search_mask() const {
+	ERR_FAIL_COND_V(!search_panel, "");
+	return search_panel->get_text();
+}
+
+void TreeSearch::_find_matching_entries(TreeItem *p_tree_item, const String &p_search_mask, Vector<TreeItem *> &p_accum) const {
+	if (!p_tree_item) {
+		return;
+	}
+
+	StringSearchIndices item_search_indices = _substring_bounds(p_tree_item->get_text(0), p_search_mask);
+	if (item_search_indices.hit()) {
+		p_accum.push_back(p_tree_item);
+	}
+
+	for (int i = 0; i < p_tree_item->get_child_count(); i++) {
+		TreeItem *child = p_tree_item->get_child(i);
+		_find_matching_entries(child, p_search_mask, p_accum);
+	}
+
+	// Sort the result if we are at the root.
+	if (p_tree_item == p_tree_item->get_tree()->get_root()) {
+		p_accum.sort();
+	}
+
+	return;
+}
+
+// Returns the lower and upper bounds of a substring. Does fuzzy search: Simply looks if words exist in right ordering.
+// Also ignores case if p_search_mask is lowercase. Example:
+// p_searcheable = "TimeLimit 2 sec", p_search_mask = limit 2 sec -> [4,14]. With p_search_mask = "LimiT 2 SEC" or "Limit sec 2" -> [-1,-1]
+TreeSearch::StringSearchIndices TreeSearch::_substring_bounds(const String &p_searchable, const String &p_search_mask) const {
+	StringSearchIndices result;
+	result.lower = UPPER_BOUND;
+	result.upper = 0;
+
+	if (p_search_mask.is_empty()) {
+		return result; // Early return if search_mask is empty.
+	}
+
+	// Determine if the search should be case-insensitive.
+	bool is_case_insensitive = (p_search_mask == p_search_mask.to_lower());
+	String searchable_processed = is_case_insensitive ? p_searchable.to_lower() : p_searchable;
+
+	PackedStringArray words = p_search_mask.split(" ");
+	int word_position = 0;
+
+	for (const String &word : words) {
+		if (word.is_empty()) {
+			continue; // Skip empty words.
+		}
+
+		String word_processed = is_case_insensitive ? word.to_lower() : word;
+
+		// Find the position of the next word in the searchable string.
+		word_position = searchable_processed.find(word_processed, word_position);
+
+		if (word_position < 0) {
+			// If any word is not found, return an empty StringSearchIndices.
+			return StringSearchIndices();
+		}
+
+		// Update lower and upper bounds.
+		result.lower = MIN(result.lower, word_position);
+		result.upper = MAX(result.upper, static_cast<int>(word_position + word.length()));
+	}
+
+	return result;
+}
+
+void TreeSearch::_select_item(TreeItem *p_item) {
+	if (!p_item) {
+		return;
+	}
+
+	ERR_FAIL_COND(!tree_reference || p_item->get_tree() != tree_reference);
+
+	// First unfold ancestors
+	TreeItem *ancestor = p_item->get_parent();
+	while (ancestor) {
+		ancestor->set_collapsed(false);
+		ancestor = ancestor->get_parent();
+	}
+	// Then scroll to [item]
+	tree_reference->scroll_to_item(p_item);
+
+	// ...and select it
+	tree_reference->deselect_all();
+	tree_reference->set_selected(p_item, 0);
+}
+
+void TreeSearch::_select_first_match() {
+	if (matching_entries.size() == 0) {
+		return;
+	}
+	for (int i = 0; i < ordered_tree_items.size(); i++) {
+		TreeItem *item = ordered_tree_items[i];
+		if (!_vector_has_bsearch(matching_entries, item)) {
+			continue;
+		}
+		_select_item(item);
+		return;
+	}
+}
+
+void TreeSearch::_select_last_match() {
+	if (matching_entries.size() == 0) {
+		return;
+	}
+	for (int i = ordered_tree_items.size() - 1; i >= 0; i--) {
+		TreeItem *item = ordered_tree_items[i];
+		if (!_vector_has_bsearch(matching_entries, item)) {
+			continue;
+		}
+		_select_item(item);
+		return;
+	}
+}
+
+void TreeSearch::_select_previous_match() {
+	if (matching_entries.size() == 0) {
+		return;
+	}
+
+	TreeItem *selected = tree_reference->get_selected();
+	if (!selected) {
+		_select_last_match();
+		return;
+	}
+	// Find [selected_idx] among ordered_tree_items.
+	int selected_idx = 0;
+	for (int i = ordered_tree_items.size() - 1; i >= 0; i--) {
+		if (ordered_tree_items[i] == selected) {
+			selected_idx = i;
+			break;
+		}
+	}
+	// Find first entry before [selected_idx].
+	for (int i = MIN(ordered_tree_items.size() - 1, selected_idx) - 1; i >= 0; i--) {
+		TreeItem *item = ordered_tree_items[i];
+		if (_vector_has_bsearch(matching_entries, item)) {
+			_select_item(item);
+			return;
+		}
+	}
+	// Wrap around.
+	_select_last_match();
+}
+
+void TreeSearch::_select_next_match() {
+	if (matching_entries.size() == 0) {
+		return;
+	}
+
+	TreeItem *selected = tree_reference->get_selected();
+	if (!selected) {
+		_select_first_match();
+		return;
+	}
+
+	// Find [selected_idx] among ordered_tree_items
+	int selected_idx = 0;
+	for (int i = 0; i < ordered_tree_items.size(); i++) {
+		if (ordered_tree_items[i] == selected) {
+			selected_idx = i;
+			break;
+		}
+	}
+
+	// Find first entry after [selected_idx].
+	for (int i = MAX(0, selected_idx) + 1; i < ordered_tree_items.size(); i++) {
+		TreeItem *item = ordered_tree_items[i];
+		if (_vector_has_bsearch(matching_entries, item)) {
+			_select_item(item);
+			return;
+		}
+	}
+	// Wrap around.
+	_select_first_match();
+}
+
+void TreeSearch::_on_search_panel_closed() {
+	if (!tree_reference) {
+		return;
+	}
+	tree_reference->grab_focus();
+}
+
+template <typename T>
+inline bool TreeSearch::_vector_has_bsearch(Vector<T *> &p_vec, T *element) const {
+	int idx = p_vec.bsearch(element, true);
+	bool in_array = idx >= 0 && idx < p_vec.size();
+
+	return in_array && p_vec[idx] == element;
+}
+
+void TreeSearch::notify_item_edited(TreeItem *item) {
+	if (item->get_cell_mode(0) != TreeItem::CELL_MODE_CUSTOM) {
+		return;
+	}
+	_highlight_tree_item(item);
+}
+
+// Called as a post-processing step for the already constructed tree.
+void TreeSearch::update_search(Tree *p_tree) {
+	ERR_FAIL_COND(!search_panel || !p_tree);
+
+	tree_reference = p_tree;
+
+	if (!tree_reference->get_root()) {
+		return;
+	}
+
+	if (!search_panel->is_visible() || search_panel->get_text().length() == 0) {
+		// Clear and redraw if search was active recently.
+		if (was_searched_recently) {
+			number_matches.clear();
+			matching_entries.clear();
+
+			_clear_filter();
+
+			was_searched_recently = false;
+			p_tree->queue_redraw();
+		}
+		return;
+	}
+	was_searched_recently = true;
+
+	String search_mask = search_panel->get_text();
+	TreeSearchMode search_mode = search_panel->get_search_mode();
+
+	_update_ordered_tree_items(p_tree->get_root());
+	_update_matching_entries(search_mask);
+	_update_number_matches();
+
+	_highlight_tree();
+	if (search_mode == TreeSearchMode::FILTER) {
+		_filter_tree();
+		was_filtered_recently = true;
+	} else if (was_filtered_recently) {
+		_clear_filter();
+		was_filtered_recently = false;
+	}
+	_clean_callable_cache();
+}
+
+TreeSearch::TreeSearch(TreeSearchPanel *p_search_panel) {
+	search_panel = p_search_panel;
+	search_panel->connect(LW_NAME(text_submitted), callable_mp(this, &TreeSearch::_select_next_match));
+	search_panel->connect(LW_NAME(Close), callable_mp(this, &TreeSearch::_on_search_panel_closed));
+	search_panel->connect("select_previous_match", callable_mp(this, &TreeSearch::_select_previous_match));
+}
+
+/* !TreeSearch */
+
+/* ------- TreeSearchPanel ------- */
+
+void TreeSearchPanel::_initialize_controls() {
+	line_edit_search = memnew(LineEdit);
+	check_button_filter_highlight = memnew(CheckBox);
+	close_button = memnew(Button);
+	find_next_button = memnew(Button);
+	find_prev_button = memnew(Button);
+	label_filter = memnew(Label);
+
+	line_edit_search->set_placeholder(TTR("Search tree"));
+
+	close_button->set_theme_type_variation(LW_NAME(FlatButton));
+	find_next_button->set_theme_type_variation(LW_NAME(FlatButton));
+	find_prev_button->set_theme_type_variation(LW_NAME(FlatButton));
+
+	find_next_button->set_tooltip_text("Next Match");
+	find_prev_button->set_tooltip_text("Previous Match");
+
+	// Positioning and sizing
+	set_anchors_and_offsets_preset(LayoutPreset::PRESET_BOTTOM_WIDE);
+	set_v_size_flags(SIZE_SHRINK_CENTER); // Do not expand vertically
+
+	line_edit_search->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	_add_spacer(0.1); // -> Otherwise the lineedits expand margin touches the left border.
+	add_child(line_edit_search);
+	add_child(find_prev_button);
+	add_child(find_next_button);
+	_add_spacer(0.25);
+
+	add_child(check_button_filter_highlight);
+	add_child(label_filter);
+
+	_add_spacer(0.25);
+	add_child(close_button);
+}
+
+void TreeSearchPanel::_add_spacer(float p_width_multiplier) {
+	Control *spacer = memnew(Control);
+	spacer->set_custom_minimum_size(Vector2(8.0 * EDSCALE * p_width_multiplier, 0.0));
+	add_child(spacer);
+}
+
+void TreeSearchPanel::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			// Close callbacks
+			close_button->connect(LW_NAME(pressed), Callable(this, LW_NAME(set_visible)).bind(false));
+			close_button->connect(LW_NAME(pressed), Callable(this, LW_NAME(emit_signal)).bind(LW_NAME(Close)));
+			close_button->set_shortcut(LW_GET_SHORTCUT("limbo_ai/hide_tree_search")); // TODO: use internal shortcut. also sets tooltip...
+			// Search callbacks
+			Callable c_update_requested = Callable(this, LW_NAME(emit_signal)).bind("update_requested");
+			Callable c_text_submitted = Callable(this, LW_NAME(emit_signal)).bind(LW_NAME(text_submitted));
+			Callable c_select_previous_match = Callable(this, LW_NAME(emit_signal)).bind("select_previous_match");
+			find_next_button->connect(LW_NAME(pressed), c_text_submitted);
+			find_prev_button->connect(LW_NAME(pressed), c_select_previous_match);
+
+			line_edit_search->connect(LW_NAME(text_changed), c_update_requested.unbind(1));
+			check_button_filter_highlight->connect(LW_NAME(pressed), c_update_requested);
+			line_edit_search->connect(LW_NAME(text_submitted), c_text_submitted.unbind(1));
+			break;
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			BUTTON_SET_ICON(close_button, get_theme_icon(LW_NAME(Close), LW_NAME(EditorIcons)));
+			BUTTON_SET_ICON(find_prev_button, get_theme_icon("MoveUp", LW_NAME(EditorIcons)));
+			BUTTON_SET_ICON(find_next_button, get_theme_icon("MoveDown", LW_NAME(EditorIcons)));
+			label_filter->set_text(TTR("Filter"));
+			break;
+		}
+	}
+}
+
+void TreeSearchPanel::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("update_requested"));
+	ADD_SIGNAL(MethodInfo(LW_NAME(text_submitted)));
+	ADD_SIGNAL(MethodInfo("select_previous_match"));
+	ADD_SIGNAL(MethodInfo(LW_NAME(Close)));
+}
+
+TreeSearchPanel::TreeSearchPanel() {
+	_initialize_controls();
+	set_visible(false);
+}
+
+TreeSearch::TreeSearchMode TreeSearchPanel::get_search_mode() const {
+	if (!check_button_filter_highlight || !check_button_filter_highlight->is_pressed()) {
+		return TreeSearch::TreeSearchMode::HIGHLIGHT;
+	}
+	return TreeSearch::TreeSearchMode::FILTER;
+}
+
+String TreeSearchPanel::get_text() const {
+	if (!line_edit_search) {
+		return String();
+	}
+	return line_edit_search->get_text();
+}
+
+TreeSearch::SearchInfo TreeSearchPanel::get_search_info() const {
+	TreeSearch::SearchInfo result;
+	result.search_mask = get_text();
+	result.search_mode = get_search_mode();
+	result.visible = is_visible();
+	return result;
+}
+
+void TreeSearchPanel::set_search_info(const TreeSearch::SearchInfo &p_search_info) {
+	line_edit_search->set_text(p_search_info.search_mask);
+	check_button_filter_highlight->set_pressed(p_search_info.search_mode == TreeSearch::TreeSearchMode::FILTER);
+	set_visible(p_search_info.visible);
+	emit_signal("update_requested");
+}
+
+void TreeSearchPanel::focus_editor() {
+	line_edit_search->grab_focus();
+}
+
+/* !TreeSearchPanel */
+
+#endif // TOOLS_ENABLED

--- a/editor/tree_search.cpp
+++ b/editor/tree_search.cpp
@@ -591,6 +591,7 @@ TreeSearchPanel::TreeSearchPanel() {
 
 	find_next_button->set_tooltip_text("Next Match");
 	find_prev_button->set_tooltip_text("Previous Match");
+	line_edit_search->set_tooltip_text("Match case if input contains capital letter.");
 
 	// Positioning and sizing
 	set_anchors_and_offsets_preset(LayoutPreset::PRESET_BOTTOM_WIDE);

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -1,0 +1,161 @@
+/**
+ * tree_search.h
+ * =============================================================================
+ * Copyright 2021-2024 Serhii Snitsaruk
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#ifdef TOOLS_ENABLED
+
+#ifndef TREE_SEARCH_H
+#define TREE_SEARCH_H
+
+#ifdef LIMBOAI_MODULE
+#include "core/templates/hash_map.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/flow_container.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/tree.h"
+#endif // LIMBOAI_MODULE
+
+#ifdef LIMBOAI_GDEXTENSION
+#include <godot_cpp/classes/check_box.hpp>
+#include <godot_cpp/classes/h_flow_container.hpp>
+#include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/line_edit.hpp>
+#include <godot_cpp/classes/tree.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#endif // LIMBOAI_GDEXTENSION
+
+using namespace godot;
+
+class TreeSearchPanel;
+
+class TreeSearch : public RefCounted {
+	GDCLASS(TreeSearch, RefCounted)
+private:
+	struct StringSearchIndices {
+		// initialize to opposite bounds.
+		int lower = -1;
+		int upper = -1;
+
+		bool hit() {
+			return 0 <= lower && lower < upper;
+		}
+	};
+
+	TreeSearchPanel *search_panel;
+
+	// For TaskTree: These are updated when the tree is updated through TaskTree::_create_tree.
+	Tree *tree_reference;
+	// Linearized ordering of tree items.
+	Vector<TreeItem *> ordered_tree_items;
+	// Entires that match the search mask.
+	// TODO: Decide if this can be removed. It can be implicitly inferred from number_matches.
+	Vector<TreeItem *> matching_entries;
+	// Number of descendant matches for each tree item.
+	HashMap<TreeItem *, int> number_matches;
+	// Custom draw-callbacks for each tree item.
+	HashMap<TreeItem *, Callable> callable_cache;
+
+	bool was_searched_recently = false; // Performance
+	bool was_filtered_recently = false; // Performance
+
+	void _clean_callable_cache();
+
+	// update_search() calls these
+	void _filter_tree();
+	void _filter_tree(TreeItem *item, bool p_parent_matching);
+	void _clear_filter();
+
+	void _highlight_tree();
+	void _highlight_tree_item(TreeItem *p_tree_item);
+
+	// Custom draw-Callback (bind inherited Callable).
+	void _draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable p_parent_draw_method);
+
+	void _update_matching_entries(const String &p_search_mask);
+	void _update_ordered_tree_items(TreeItem *p_tree_item);
+	void _update_number_matches();
+	void _update_number_matches(TreeItem *item);
+
+	void _find_matching_entries(TreeItem *p_tree_item, const String &p_search_mask, Vector<TreeItem *> &p_accum) const;
+	String _get_search_mask() const;
+	StringSearchIndices _substring_bounds(const String &p_searchable, const String &p_search_mask) const;
+
+	void _select_item(TreeItem *p_item);
+	void _select_first_match();
+	void _select_last_match();
+
+	void _select_previous_match();
+	void _select_next_match();
+
+	void _on_search_panel_closed();
+
+	// TODO: make p_vec ref `const` once Vector::bsearch is const.
+	// See: https://github.com/godotengine/godot/pull/90341
+	template <typename T>
+	bool _vector_has_bsearch(Vector<T *> &p_vec, T *element) const;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	enum TreeSearchMode {
+		HIGHLIGHT = 0,
+		FILTER = 1
+	};
+
+	struct SearchInfo {
+		String search_mask;
+		TreeSearchMode search_mode;
+		bool visible;
+	};
+
+	// Called as a post-processing step for the already constructed tree.
+	void update_search(Tree *p_tree);
+
+	// This restores the highlight-drawing if a single item got edited.
+	void notify_item_edited(TreeItem *p_item);
+
+	TreeSearch() { ERR_FAIL_MSG("TreeSearch needs a TreeSearchPanel to work properly."); }
+	TreeSearch(TreeSearchPanel *p_search_panel);
+};
+
+// --------------------------------------------
+
+class TreeSearchPanel : public HFlowContainer {
+	GDCLASS(TreeSearchPanel, HFlowContainer)
+
+private:
+	Button *toggle_button_filter_highlight;
+	Button *close_button;
+	Button *find_next_button;
+	Button *find_prev_button;
+	Label *label_filter;
+	LineEdit *line_edit_search;
+	CheckBox *check_button_filter_highlight;
+	void _initialize_controls();
+	void _add_spacer(float width_multiplier = 1.f);
+
+	void _notification(int p_what);
+
+protected:
+	static void _bind_methods();
+
+public:
+	String get_text() const;
+	TreeSearch::TreeSearchMode get_search_mode() const;
+	TreeSearch::SearchInfo get_search_info() const;
+	void set_search_info(const TreeSearch::SearchInfo &p_search_info);
+	void focus_editor();
+	TreeSearchPanel();
+};
+
+#endif // TREE_SEARCH_H
+#endif // ! TOOLS_ENABLED

--- a/editor/tree_search.h
+++ b/editor/tree_search.h
@@ -77,7 +77,7 @@ private:
 	void _highlight_tree_item(TreeItem *p_tree_item);
 
 	// Custom draw-Callback (bind inherited Callable).
-	void _draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable p_parent_draw_method);
+	void _draw_highlight_item(TreeItem *p_tree_item, const Rect2 p_rect, const Callable &p_parent_draw_method);
 
 	void _update_matching_entries(const String &p_search_mask);
 	void _update_ordered_tree_items(TreeItem *p_tree_item);
@@ -140,7 +140,6 @@ private:
 	Label *label_filter;
 	LineEdit *line_edit_search;
 	CheckBox *check_button_filter_highlight;
-	void _initialize_controls();
 	void _add_spacer(float width_multiplier = 1.f);
 
 	void _notification(int p_what);

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -106,6 +106,7 @@
 #include "util/limbo_string_names.h"
 #include "util/limbo_task_db.h"
 #include "util/limbo_utility.h"
+#include "editor/tree_search.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/debugger/behavior_tree_view.h"
@@ -267,6 +268,8 @@ void initialize_limboai_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(OwnerPicker);
 		GDREGISTER_CLASS(LimboAIEditor);
 		GDREGISTER_CLASS(LimboAIEditorPlugin);
+		GDREGISTER_INTERNAL_CLASS(TreeSearchPanel);
+		GDREGISTER_INTERNAL_CLASS(TreeSearch);
 #endif // LIMBOAI_GDEXTENSION
 
 		EditorPlugins::add_by_type<LimboAIEditorPlugin>();

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -46,6 +46,7 @@ LimboStringNames::LimboStringNames() {
 	button_up = SN("button_up");
 	call_deferred = SN("call_deferred");
 	changed = SN("changed");
+	Close = SN("Close");
 	dark_color_2 = SN("dark_color_2");
 	Debug = SN("Debug");
 	disabled_font_color = SN("disabled_font_color");
@@ -58,6 +59,7 @@ LimboStringNames::LimboStringNames() {
 	EditorFonts = SN("EditorFonts");
 	EditorIcons = SN("EditorIcons");
 	EditorStyles = SN("EditorStyles");
+	emit_signal = SN("emit_signal");
 	entered = SN("entered");
 	error_value = SN("error_value");
 	EVENT_FAILURE = SN("failure");
@@ -66,6 +68,8 @@ LimboStringNames::LimboStringNames() {
 	exited = SN("exited");
 	favorite_tasks_changed = SN("favorite_tasks_changed");
 	Favorites = SN("Favorites");
+	FlatButton = SN("FlatButton");
+	Focus = SN("Focus");
 	focus_exited = SN("focus_exited");
 	font = SN("font");
 	font_color = SN("font_color");
@@ -77,6 +81,7 @@ LimboStringNames::LimboStringNames() {
 	GuiTreeArrowRight = SN("GuiTreeArrowRight");
 	HeaderSmall = SN("HeaderSmall");
 	Help = SN("Help");
+	h_separation = SN("h_separation");
 	icon_max_width = SN("icon_max_width");
 	class_icon_size = SN("class_icon_size");
 	id_pressed = SN("id_pressed");
@@ -120,6 +125,7 @@ LimboStringNames::LimboStringNames() {
 	separation = SN("separation");
 	set_custom_name = SN("set_custom_name");
 	set_root_task = SN("set_root_task");
+	set_visible = SN("set_visible");
 	set_v_scroll = SN("set_v_scroll");
 	setup = SN("setup");
 	started = SN("started");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -62,6 +62,7 @@ public:
 	StringName button_up;
 	StringName call_deferred;
 	StringName changed;
+	StringName Close;
 	StringName dark_color_2;
 	StringName Debug;
 	StringName disabled_font_color;
@@ -74,6 +75,7 @@ public:
 	StringName EditorFonts;
 	StringName EditorIcons;
 	StringName EditorStyles;
+	StringName emit_signal;
 	StringName entered;
 	StringName error_value;
 	StringName EVENT_FAILURE;
@@ -82,6 +84,8 @@ public:
 	StringName exited;
 	StringName favorite_tasks_changed;
 	StringName Favorites;
+	StringName FlatButton;
+	StringName Focus;
 	StringName focus_exited;
 	StringName font_color;
 	StringName font_size;
@@ -93,6 +97,7 @@ public:
 	StringName GuiTreeArrowRight;
 	StringName HeaderSmall;
 	StringName Help;
+	StringName h_separation;
 	StringName icon_max_width;
 	StringName class_icon_size;
 	StringName id_pressed;
@@ -136,6 +141,7 @@ public:
 	StringName separation;
 	StringName set_custom_name;
 	StringName set_root_task;
+	StringName set_visible;
 	StringName set_v_scroll;
 	StringName setup;
 	StringName started;


### PR DESCRIPTION
Closes #192

Tested with GDExtension and Module.

Features:
- *Tree highlighting*: Highlights items that match the search query.
- *Counting descendants*: Shows the number of matching items within collapsed branches.
- *Jump to next match*: on enter.
- (Limbo-)*Shortcut*: Default CTRL-F. 
- *Menu entry*: Misc->Search Tree.

Known issues:
- [x] Unnecessarily redundant signals ([af15dde](https://github.com/limbonaut/limboai/pull/229/commits/af15dde4c896b76db66689d49ced72730b8e7775))
-  [x] ~~`TreeSearch::_draw_highlight_item`: uses one magic number~~ (same as engine code)
- Performance
   - [x] `TreeSearch::_find_matching_entries` et al ([cc8f099](https://github.com/limbonaut/limboai/pull/229/commits/cc8f099d82f9aeaa3c3affd2fb3bf588834bdd5e))
     - Can be solved by making it iterative instead of recursive, using linear push_back instead of insert and sorting once.
   - [x] Searches do a whole tree reconstruction for now: Noticeable lag. (https://github.com/monxa/limboai/pull/1)
- [x] Editor scaling needs fixing ([380f80c](https://github.com/limbonaut/limboai/pull/229/commits/380f80c2b3166548f01743bd96e21e2ef418135d))
- [x] ~~Searchbar spacing should be adjusted.~~ (Already similar to Docs/Script search bar with [8c32395](https://github.com/limbonaut/limboai/pull/229/commits/8c323956e3afe74243fff791ff807167bd913baf))
- [ ] ~~Word highlight drawing might be too obstructive. Especially in filter mode.~~ (Will be solved after this is merged)
- [x] Jumping through entries currently inconsistent ([8d29f16](https://github.com/limbonaut/limboai/pull/229/commits/8d29f16963c30dcd073964b028ff6d5f1303b952), [47706e9](https://github.com/limbonaut/limboai/pull/229/commits/47706e9480b6fc831e171f9a6c39ca0d7b6d988c))
- [x] Filtering unstable. ([74cf985](https://github.com/limbonaut/limboai/pull/229/commits/74cf9855a7fed51ed6e373ed14599a64a62eae46), [465757e](https://github.com/limbonaut/limboai/pull/229/commits/465757eec830a73da446973bcce2c640e9a794a6))
- [ ] Decide if the current case matching behavior needs adjustment. Current: Match case when input includes capital letter.

Wishlist (non-blockers)
1. Word highlight drawing might be too obstructive. Especially in filter mode.
2. - [x] Remember separate ~~search-mask~~ `SearchInfo` for each tab. ([10c8f58](https://github.com/limbonaut/limboai/pull/229/commits/10c8f58ca9b9e3c9034b7eb5b5dc52e2677a18c7))
3. - [x] Buttons for select next/previous entry (align with script/docs viewport). ([ec6c4c3](https://github.com/limbonaut/limboai/pull/229/commits/ec6c4c3036a62a9d8f47f4f61f610cff95964389))
4. Remember and restore tree collapse on jumping

This pr includes a significant amount of new code (~500 lines). I would greatly appreciate any feedback, especially regarding the known issues listed above.

[demo_filter_tree.webm](https://github.com/user-attachments/assets/76fb8ed1-3ff2-4fa7-948a-101ed633b7ac)
