### PR TITLE
Duplicate `BBParam` instances in typed arrays in `BTTask::clone()`

### DIFF
--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -40,6 +40,7 @@ LimboStringNames::LimboStringNames() {
 	add_child = SN("add_child");
 	add_child_at_index = SN("add_child_at_index");
 	AnimationFilter = SN("AnimationFilter");
+	BBParam = SN("BBParam");
 	behavior_tree_finished = SN("behavior_tree_finished");
 	bold = SN("bold");
 	button_down = SN("button_down");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -56,6 +56,7 @@ public:
 	StringName add_child;
 	StringName Add;
 	StringName AnimationFilter;
+	StringName BBParam;
 	StringName behavior_tree_finished;
 	StringName bold;
 	StringName button_down;


### PR DESCRIPTION
Fixes issue with `CallMethod` arguments being shared between tasks after duplication or copy/paste. Task properties with `Array[BBParam*]` type are now fully duplicated, with each instance of `BBParam` resource duplicated as well.
