### PR TITLE
Improve workflow with built-in BT resources

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -476,6 +476,14 @@ void LimboAIEditor::_process_shortcut_input(const Ref<InputEvent> &p_event) {
 		} else if (LW_IS_SHORTCUT("limbo_ai/close_tab", p_event)) {
 			_tab_menu_option_selected(TAB_CLOSE);
 			handled = true;
+		} else if (LW_IS_SHORTCUT("limbo_ai/editor_save_scene", p_event)) {
+			// This intercepts the editor save action, but does not set the event as handled because we don't know the user's intention.
+			// We just want to save the currently edited BT as well, which may cause a loop with built-in resource if done from "_save_external_data".
+			// Workaround for: https://github.com/limbonaut/limboai/issues/240#issuecomment-2453087424
+			if (task_tree->get_bt().is_valid() && RESOURCE_IS_BUILT_IN(task_tree->get_bt())) {
+				_on_save_pressed();
+			}
+			handled = false; // intentionally not set as handled
 		}
 	}
 
@@ -1584,6 +1592,9 @@ LimboAIEditor::LimboAIEditor() {
 	LW_SHORTCUT("limbo_ai/close_tab", TTR("Close Tab"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(W)));
 	LW_SHORTCUT("limbo_ai/find_task", TTR("Find Task"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(F)));
 	LW_SHORTCUT("limbo_ai/hide_tree_search", TTR("Close Search"), (Key)(LW_KEY(ESCAPE)));
+
+	// Intercept editor save scene action.
+	LW_SHORTCUT("limbo_ai/editor_save_scene", TTR("Save Scene"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(S)));
 
 	set_process_shortcut_input(true);
 

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1588,7 +1588,7 @@ LimboAIEditor::LimboAIEditor() {
 	LW_SHORTCUT("limbo_ai/save_behavior_tree", TTR("Save Behavior Tree"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY_MASK(ALT) | LW_KEY(S)));
 	LW_SHORTCUT("limbo_ai/load_behavior_tree", TTR("Load Behavior Tree"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY_MASK(ALT) | LW_KEY(L)));
 	LW_SHORTCUT("limbo_ai/open_debugger", TTR("Open Debugger"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY_MASK(ALT) | LW_KEY(D)));
-	LW_SHORTCUT("limbo_ai/jump_to_owner", TTR("Jump to Owner"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(J)));
+	LW_SHORTCUT("limbo_ai/jump_to_owner", TTR("Jump to Owner"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(G)));
 	LW_SHORTCUT("limbo_ai/close_tab", TTR("Close Tab"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(W)));
 	LW_SHORTCUT("limbo_ai/find_task", TTR("Find Task"), (Key)(LW_KEY_MASK(CMD_OR_CTRL) | LW_KEY(F)));
 	LW_SHORTCUT("limbo_ai/hide_tree_search", TTR("Close Search"), (Key)(LW_KEY(ESCAPE)));

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -241,7 +241,6 @@ private:
 	void _on_tree_task_selected(const Ref<BTTask> &p_task);
 	void _on_tree_task_activated();
 	void _on_visibility_changed();
-	void _on_header_pressed();
 	void _on_save_pressed();
 	void _on_history_back();
 	void _on_history_forward();

--- a/editor/task_tree.h
+++ b/editor/task_tree.h
@@ -95,7 +95,7 @@ protected:
 public:
 	void load_bt(const Ref<BehaviorTree> &p_behavior_tree);
 	void unload();
-	Ref<BehaviorTree> get_bt() const { return bt; }
+	_FORCE_INLINE_ Ref<BehaviorTree> get_bt() const { return bt; }
 	void update_tree() { _update_tree(); }
 	void update_task(const Ref<BTTask> &p_task);
 	void add_selection(const Ref<BTTask> &p_task);


### PR DESCRIPTION
Improves workflow with built-in BT resources, namely:
- Save the edited built-in BT resource with `Ctrl+S`
- Open the owner scene when switching to a built-in BT
- Use `Ctrl+G` to switch to the owner scene while in the LimboAI editor

Fixes remaining issues laid out in #240