### PR TITLE
Remove arbitrary limit on user task directories

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1044,7 +1044,7 @@ void LimboAIEditor::_on_filesystem_changed() {
 }
 
 void LimboAIEditor::_on_new_script_pressed() {
-	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir");
+	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dirs");
 	ERR_FAIL_INDEX_MSG(0, user_task_directories.size(), "LimboAI: No user task directory set");
 	String default_task_dir = user_task_directories[0];
 	SCRIPT_EDITOR()->open_script_create_dialog("BTAction", default_task_dir.path_join("new_task"));
@@ -1417,8 +1417,8 @@ void LimboAIEditor::_update_banners() {
 		}
 	}
 
-	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir");
-	for (String task_dir : user_task_directories) {
+	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dirs");
+	for (const String &task_dir : user_task_directories) {
 		if (!task_dir.is_empty() && !DirAccess::dir_exists_absolute(task_dir)) {
 			ActionBanner *banner = memnew(ActionBanner);
 			banner->set_text(vformat(TTR("Task folder not found: %s"), task_dir));
@@ -1897,7 +1897,7 @@ LimboAIEditor::LimboAIEditor() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/behavior_tree_default_dir", PROPERTY_HINT_DIR), "res://ai/trees");
 	PackedStringArray user_task_dir_default;
 	user_task_dir_default.append("res://ai/tasks");
-	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "limbo_ai/behavior_tree/user_task_dir", PROPERTY_HINT_TYPE_STRING , "4/14:"), user_task_dir_default);
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "limbo_ai/behavior_tree/user_task_dirs", PROPERTY_HINT_TYPE_STRING , vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR)), user_task_dir_default);
 
 	String bt_default_dir = GLOBAL_GET("limbo_ai/behavior_tree/behavior_tree_default_dir");
 	save_dialog->set_current_dir(bt_default_dir);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1897,7 +1897,7 @@ LimboAIEditor::LimboAIEditor() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "limbo_ai/behavior_tree/behavior_tree_default_dir", PROPERTY_HINT_DIR), "res://ai/trees");
 	PackedStringArray user_task_dir_default;
 	user_task_dir_default.append("res://ai/tasks");
-	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "limbo_ai/behavior_tree/user_task_dirs", PROPERTY_HINT_TYPE_STRING , vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR)), user_task_dir_default);
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "limbo_ai/behavior_tree/user_task_dirs", PROPERTY_HINT_TYPE_STRING, vformat("%s/%s:", Variant::STRING, PROPERTY_HINT_DIR)), user_task_dir_default);
 
 	String bt_default_dir = GLOBAL_GET("limbo_ai/behavior_tree/behavior_tree_default_dir");
 	save_dialog->set_current_dir(bt_default_dir);

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -211,7 +211,7 @@ private:
 	void _update_task_tree(const Ref<BehaviorTree> &p_bt, const Ref<BTTask> &p_specific_task = nullptr);
 	void _disable_editing();
 	void _set_as_dirty(const Ref<BehaviorTree> &p_bt, bool p_dirty);
-	void _create_user_task_dir();
+	void _create_user_task_dir(String task_dir);
 	void _remove_task_from_favorite(const String &p_task);
 	void _save_and_restart();
 	void _extract_subtree(const String &p_path);

--- a/util/limbo_task_db.cpp
+++ b/util/limbo_task_db.cpp
@@ -95,8 +95,8 @@ void LimboTaskDB::scan_user_tasks() {
 		tasks_cache[LimboTaskDB::get_misc_category()] = List<String>();
 	}
 
-	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir");
-	for String user_task_dir : user_task_directories) {
+	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dirs");
+	for (const String &user_task_dir : user_task_directories) {
 		_populate_from_user_dir(user_task_dir, &tasks_cache);
 	}
 

--- a/util/limbo_task_db.cpp
+++ b/util/limbo_task_db.cpp
@@ -95,9 +95,9 @@ void LimboTaskDB::scan_user_tasks() {
 		tasks_cache[LimboTaskDB::get_misc_category()] = List<String>();
 	}
 
-	for (int i = 1; i < 4; i++) {
-		String dir1 = ProjectSettings::get_singleton()->get_setting_with_override("limbo_ai/behavior_tree/user_task_dir_" + itos(i));
-		_populate_from_user_dir(dir1, &tasks_cache);
+	PackedStringArray user_task_directories = GLOBAL_GET("limbo_ai/behavior_tree/user_task_dir");
+	for String user_task_dir : user_task_directories) {
+		_populate_from_user_dir(user_task_dir, &tasks_cache);
 	}
 
 	for (KeyValue<String, List<String>> &E : tasks_cache) {


### PR DESCRIPTION
resolves #256 

This change will introduce a compatibility break, as projects that have changed the default settings in regards to user task directories will lose their values. If, however, a project only ever made new tasks in the default user task directory, it should not affect those projects.