### PR TITLE
Enable existing BlackboardPlan features for NIL variables

### DIFF
--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -200,7 +200,7 @@ void BlackboardPlan::_get_property_list(List<PropertyInfo> *p_list) const {
 
 #ifdef TOOLS_ENABLED
 		// * Editor
-		if (!_is_var_hidden(var_name, var)) {
+		if (!_is_var_nil(var) || !_is_var_private(var_name, var)) {
 			if (has_mapping(var_name) || has_property_binding(var_name)) {
 				p_list->push_back(PropertyInfo(Variant::STRING, var_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
 			} else {
@@ -226,7 +226,7 @@ void BlackboardPlan::_get_property_list(List<PropertyInfo> *p_list) const {
 	if (is_mapping_enabled()) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Mapping", PROPERTY_HINT_NONE, "mapping/", PROPERTY_USAGE_GROUP));
 		for (const Pair<StringName, BBVariable> &p : var_list) {
-			if (_is_var_hidden(p.first, p.second)) {
+			if (_is_var_private(p.first, p.second)) {
 				continue;
 			}
 			if (unlikely(has_property_binding(p.first))) {
@@ -242,7 +242,7 @@ void BlackboardPlan::_get_property_list(List<PropertyInfo> *p_list) const {
 	// * Binding
 	p_list->push_back(PropertyInfo(Variant::NIL, "Binding", PROPERTY_HINT_NONE, "binding/", PROPERTY_USAGE_GROUP));
 	for (const Pair<StringName, BBVariable> &p : var_list) {
-		if (_is_var_hidden(p.first, p.second)) {
+		if (_is_var_nil(p.second) || _is_var_private(p.first, p.second)) {
 			continue;
 		}
 		if (unlikely(has_mapping(p.first))) {

--- a/blackboard/blackboard_plan.h
+++ b/blackboard/blackboard_plan.h
@@ -51,7 +51,8 @@ private:
 	// If true, NodePath variables will be prefetched, so that the vars will contain node pointers instead (upon BB creation/population).
 	bool prefetch_nodepath_vars = true;
 
-	_FORCE_INLINE_ bool _is_var_hidden(const String &p_name, const BBVariable &p_var) const { return p_var.get_type() == Variant::NIL || (is_derived() && p_name.begins_with("_")); }
+	_FORCE_INLINE_ bool _is_var_nil(const BBVariable &p_var) const { return p_var.get_type() == Variant::NIL; }
+	_FORCE_INLINE_ bool _is_var_private(const String &p_name, const BBVariable &p_var) const { return is_derived() && p_name.begins_with("_"); }
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_property_variable_name.cpp
+++ b/editor/editor_property_variable_name.cpp
@@ -89,7 +89,7 @@ void EditorPropertyVariableName::_update_status() {
 		BUTTON_SET_ICON(status_btn, theme_cache.var_empty_icon);
 		status_btn->set_tooltip_text(TTR("Variable name not specified.\nClick to open the blackboard plan."));
 	} else if (plan->has_var(var_name)) {
-		if (expected_type == Variant::NIL || plan->get_var(var_name).get_type() == expected_type) {
+		if (expected_type == Variant::NIL || plan->get_var(var_name).get_type() == Variant::NIL || plan->get_var(var_name).get_type() == expected_type) {
 			BUTTON_SET_ICON(status_btn, theme_cache.var_exists_icon);
 			status_btn->set_tooltip_text(TTR("This variable is present in the blackboard plan.\nClick to open the blackboard plan."));
 		} else {


### PR DESCRIPTION
Do not show warning for NIL type BlackboardPlan variables on BBParam.
Enable variable mapping for NIL type public BlackboardPlan variables.