### PR TITLE
Amend logic error in BlackboardPlan variable listing

### DIFF
--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -200,7 +200,7 @@ void BlackboardPlan::_get_property_list(List<PropertyInfo> *p_list) const {
 
 #ifdef TOOLS_ENABLED
 		// * Editor
-		if (!_is_var_nil(var) || !_is_var_private(var_name, var)) {
+		if (!_is_var_nil(var) && !_is_var_private(var_name, var)) {
 			if (has_mapping(var_name) || has_property_binding(var_name)) {
 				p_list->push_back(PropertyInfo(Variant::STRING, var_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
 			} else {


### PR DESCRIPTION
A small but important oversight from the previous PR results in nil variables OR private variables being listed in the BlackboardPlan inspector. Now NEITHER of these variables will be listed. My concurrent apologies and thanks.