### PR TITLE
Fix `BTInstance` not registered in debugger in BTPlayer.set_bt_instance()

### DIFF
--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -78,6 +78,11 @@ void BTPlayer::set_bt_instance(const Ref<BTInstance> &p_bt_instance) {
 	blackboard = p_bt_instance->get_blackboard();
 	agent_node = p_bt_instance->get_agent()->get_path();
 
+#ifdef DEBUG_ENABLED
+	bt_instance->set_monitor_performance(monitor_performance);
+	bt_instance->register_with_debugger();
+#endif // DEBUG_ENABLED
+
 	blackboard_plan.unref();
 	behavior_tree.unref();
 }


### PR DESCRIPTION
Related #273