### PR TITLE
Navigate to subtree resource when clicked in editor

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -893,6 +893,14 @@ void LimboAIEditor::_on_tree_task_activated() {
 	Ref<Script> scr = selected->get_script();
 	if (scr.is_valid()) {
 		EDIT_SCRIPT(scr->get_path());
+	} else if (IS_CLASS(selected, BTSubtree)) {
+		Ref<BehaviorTree> subtree = static_cast<Ref<BTSubtree>>(selected)->get_subtree();
+		if (subtree.is_valid()) {
+			EDIT_RESOURCE(subtree);
+		} else {
+			LimboUtility::get_singleton()->open_doc_class(selected->get_class());
+		}
+		EDIT_RESOURCE(subtree);
 	} else {
 		LimboUtility::get_singleton()->open_doc_class(selected->get_class());
 	}


### PR DESCRIPTION
I keep double-clicking subtrees in my behavior trees expecting it to take me to the resource for that tree, but it takes me to the BTSubtree doc instead. This changes what happens when subtrees are activated in the editor, opening the subtree resource if one has been defined, or falling back to the BTSubtree doc otherwise. I think it makes sense for BTSubtree to be a specific exception for the action handling here.

https://github.com/user-attachments/assets/6b2dbe82-c3db-47a3-8db7-ff66e777504b

