### PR TITLE
GHA: Build editor targets for iOS & Web GDExtension libs

### DIFF
--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -108,7 +108,7 @@ jobs:
           - name: 🌐 Web (wasm32, debug)
             runner: ubuntu-20.04
             platform: web
-            target: template_debug
+            target: editor
             arch: wasm32
             should-build: ${{ !inputs.test-build }}
 
@@ -178,7 +178,7 @@ jobs:
           - name: 🍏 iOS (arm64, debug)
             runner: macos-latest
             platform: ios
-            target: template_debug
+            target: editor
             arch: arm64
             should-build: ${{ !inputs.test-build }}
 
@@ -193,7 +193,7 @@ jobs:
           - name: 🍏 iOS (simulator, debug)
             runner: macos-latest
             platform: ios
-            target: template_debug
+            target: editor
             arch: universal
             scons-flags: ios_simulator=yes
             should-build: ${{ !inputs.test-build }}

--- a/gdextension/limboai.gdextension
+++ b/gdextension/limboai.gdextension
@@ -25,11 +25,11 @@ android.debug.x86_64 = "res://addons/limboai/bin/liblimboai.android.editor.x86_6
 android.release.x86_64 = "res://addons/limboai/bin/liblimboai.android.template_release.x86_64.so"
 android.debug.x86_32 = "res://addons/limboai/bin/liblimboai.android.editor.x86_32.so"
 android.release.x86_32 = "res://addons/limboai/bin/liblimboai.android.template_release.x86_32.so"
-ios.debug.arm64 = "res://addons/limboai/bin/liblimboai.ios.template_debug.arm64.dylib"
+ios.debug.arm64 = "res://addons/limboai/bin/liblimboai.ios.editor.arm64.dylib"
 ios.release.arm64 = "res://addons/limboai/bin/liblimboai.ios.template_release.arm64.dylib"
-ios.debug.simulator = "res://addons/limboai/bin/liblimboai.ios.template_debug.universal.dylib"
+ios.debug.simulator = "res://addons/limboai/bin/liblimboai.ios.editor.universal.dylib"
 ios.release.simulator = "res://addons/limboai/bin/liblimboai.ios.template_release.universal.dylib"
-web.debug.wasm32 = "res://addons/limboai/bin/liblimboai.web.template_debug.wasm32.wasm"
+web.debug.wasm32 = "res://addons/limboai/bin/liblimboai.web.editor.wasm32.wasm"
 web.release.wasm32 = "res://addons/limboai/bin/liblimboai.web.template_release.wasm32.wasm"
 
 [icons]


### PR DESCRIPTION
Compile iOS GDExtension libs with editor support.