### PR TITLE
Feature: Enable-disable branches in the BT editor

### DIFF
--- a/bt/behavior_tree.cpp
+++ b/bt/behavior_tree.cpp
@@ -89,6 +89,10 @@ Ref<BTInstance> BehaviorTree::instantiate(Node *p_agent, const Ref<Blackboard> &
 	return BTInstance::create(root_copy, get_path(), p_instance_owner);
 }
 
+void BehaviorTree::emit_branch_changed(const Ref<BTTask> &p_branch) {
+	emit_signal(LW_NAME(branch_changed), p_branch);
+}
+
 void BehaviorTree::_plan_changed() {
 	emit_signal(LW_NAME(plan_changed));
 	emit_changed();
@@ -126,6 +130,7 @@ void BehaviorTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "root_task", PROPERTY_HINT_RESOURCE_TYPE, "BTTask", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_root_task", "get_root_task");
 
 	ADD_SIGNAL(MethodInfo("plan_changed"));
+	ADD_SIGNAL(MethodInfo("branch_changed", PropertyInfo(Variant::OBJECT, "branch", PROPERTY_HINT_RESOURCE_TYPE, "BTTask")));
 }
 
 BehaviorTree::BehaviorTree() {

--- a/bt/behavior_tree.h
+++ b/bt/behavior_tree.h
@@ -65,6 +65,8 @@ public:
 	void copy_other(const Ref<BehaviorTree> &p_other);
 	Ref<BTInstance> instantiate(Node *p_agent, const Ref<Blackboard> &p_blackboard, Node *p_instance_owner, Node *p_custom_scene_root = nullptr) const;
 
+	void emit_branch_changed(const Ref<BTTask> &p_branch);
+
 	BehaviorTree();
 	~BehaviorTree();
 };

--- a/bt/tasks/bt_action.cpp
+++ b/bt/tasks/bt_action.cpp
@@ -13,7 +13,7 @@
 
 PackedStringArray BTAction::get_configuration_warnings() {
 	PackedStringArray warnings = BTTask::get_configuration_warnings();
-	if (get_child_count_excluding_comments() != 0) {
+	if (get_enabled_child_count() != 0) {
 		warnings.append("Action can't have child tasks.");
 	}
 	return warnings;

--- a/bt/tasks/bt_comment.cpp
+++ b/bt/tasks/bt_comment.cpp
@@ -18,6 +18,10 @@
 using namespace godot;
 #endif
 
+void BTComment::set_enabled(bool p_enabled) {
+	// BTComment is always disabled.
+}
+
 Ref<BTTask> BTComment::clone() const {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		return BTTask::clone();
@@ -34,4 +38,8 @@ PackedStringArray BTComment::get_configuration_warnings() {
 		warnings.append("Can't be the root task.");
 	}
 	return warnings;
+}
+
+BTComment::BTComment() {
+	_set_enabled(false);
 }

--- a/bt/tasks/bt_comment.cpp
+++ b/bt/tasks/bt_comment.cpp
@@ -31,7 +31,7 @@ Ref<BTTask> BTComment::clone() const {
 
 PackedStringArray BTComment::get_configuration_warnings() {
 	PackedStringArray warnings = BTTask::get_configuration_warnings();
-	if (get_child_count_excluding_comments() > 0) {
+	if (get_enabled_child_count() > 0) {
 		warnings.append("Can only have other comment tasks as children.");
 	}
 	if (get_parent().is_null()) {

--- a/bt/tasks/bt_comment.h
+++ b/bt/tasks/bt_comment.h
@@ -22,8 +22,11 @@ protected:
 	static void _bind_methods() {}
 
 public:
+	virtual void set_enabled(bool p_enabled) override;
 	virtual Ref<BTTask> clone() const override;
 	virtual PackedStringArray get_configuration_warnings() override;
+
+	BTComment();
 };
 
 #endif // BT_COMMENT_H

--- a/bt/tasks/bt_composite.cpp
+++ b/bt/tasks/bt_composite.cpp
@@ -13,7 +13,7 @@
 
 PackedStringArray BTComposite::get_configuration_warnings() {
 	PackedStringArray warnings = BTTask::get_configuration_warnings();
-	if (get_child_count_excluding_comments() < 1) {
+	if (get_enabled_child_count() < 1) {
 		warnings.append("Composite should have at least one child task.");
 	}
 	return warnings;

--- a/bt/tasks/bt_condition.cpp
+++ b/bt/tasks/bt_condition.cpp
@@ -13,7 +13,7 @@
 
 PackedStringArray BTCondition::get_configuration_warnings() {
 	PackedStringArray warnings = BTTask::get_configuration_warnings();
-	if (get_child_count_excluding_comments() != 0) {
+	if (get_enabled_child_count() != 0) {
 		warnings.append("Condition task can't have child tasks.");
 	}
 	return warnings;

--- a/bt/tasks/bt_decorator.cpp
+++ b/bt/tasks/bt_decorator.cpp
@@ -13,7 +13,7 @@
 
 PackedStringArray BTDecorator::get_configuration_warnings() {
 	PackedStringArray warnings = BTTask::get_configuration_warnings();
-	if (get_child_count_excluding_comments() != 1) {
+	if (get_enabled_child_count() != 1) {
 		warnings.append("Decorator should have a single child task.");
 	}
 	return warnings;

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -296,7 +296,7 @@ void BTTask::abort() {
 	data.elapsed = 0.0;
 }
 
-int BTTask::get_child_count_excluding_comments() const {
+int BTTask::get_enabled_child_count() const {
 	int count = 0;
 	for (int i = 0; i < data.children.size(); i++) {
 		if (data.children[i]->is_enabled()) {
@@ -432,7 +432,7 @@ void BTTask::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("execute", "delta"), &BTTask::execute);
 	ClassDB::bind_method(D_METHOD("get_child", "idx"), &BTTask::get_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &BTTask::get_child_count);
-	ClassDB::bind_method(D_METHOD("get_child_count_excluding_comments"), &BTTask::get_child_count_excluding_comments);
+	ClassDB::bind_method(D_METHOD("get_enabled_child_count"), &BTTask::get_enabled_child_count);
 	ClassDB::bind_method(D_METHOD("add_child", "task"), &BTTask::add_child);
 	ClassDB::bind_method(D_METHOD("add_child_at_index", "task", "idx"), &BTTask::add_child_at_index);
 	ClassDB::bind_method(D_METHOD("remove_child", "task"), &BTTask::remove_child);
@@ -445,6 +445,10 @@ void BTTask::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_task_name"), &BTTask::get_task_name);
 	ClassDB::bind_method(D_METHOD("abort"), &BTTask::abort);
 	ClassDB::bind_method(D_METHOD("editor_get_behavior_tree"), &BTTask::editor_get_behavior_tree);
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("get_child_count_excluding_comments"), &BTTask::get_enabled_child_count);
+#endif
 
 	// Properties, setters and getters.
 	ClassDB::bind_method(D_METHOD("get_agent"), &BTTask::get_agent);

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -48,6 +48,15 @@ void BT::_bind_methods() {
 	BIND_ENUM_CONSTANT(SUCCESS);
 }
 
+void BTTask::_emit_branch_changed() {
+#ifdef TOOLS_ENABLED
+	Ref<BehaviorTree> bt = editor_get_behavior_tree();
+	if (Engine::get_singleton()->is_editor_hint() && bt.is_valid()) {
+		bt->emit_branch_changed(this);
+	}
+#endif
+}
+
 String BTTask::_generate_name() {
 	String ret;
 
@@ -107,6 +116,22 @@ void BTTask::_set_children(Array p_children) {
 	if (num_null > 0) {
 		data.children.resize(num_children - num_null);
 	}
+}
+
+void BTTask::set_enabled(bool p_enabled) {
+	data.enabled = p_enabled;
+	_emit_branch_changed();
+}
+
+bool BTTask::is_enabled_in_tree() const {
+	const BTTask *task = this;
+	while (task != nullptr) {
+		if (!task->data.enabled) {
+			return false;
+		}
+		task = task->data.parent;
+	}
+	return true;
 }
 
 void BTTask::set_display_collapsed(bool p_display_collapsed) {
@@ -177,6 +202,10 @@ void BTTask::initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard, Node
 }
 
 Ref<BTTask> BTTask::clone() const {
+	if (!data.enabled && !Engine::get_singleton()->is_editor_hint()) {
+		return nullptr;
+	}
+
 	Ref<BTTask> inst = duplicate(false);
 
 	// * Children are duplicated via children property. See _set_children().
@@ -270,7 +299,7 @@ void BTTask::abort() {
 int BTTask::get_child_count_excluding_comments() const {
 	int count = 0;
 	for (int i = 0; i < data.children.size(); i++) {
-		if (!IS_CLASS(data.children[i], BTComment)) {
+		if (data.children[i]->is_enabled()) {
 			count += 1;
 		}
 	}
@@ -437,6 +466,12 @@ void BTTask::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_children", "_get_children");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_status");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "elapsed_time", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_elapsed_time");
+
+	// `_enabled` is hidden as it has no effect after the BT is instantiated at runtime.
+	// To avoid confusion, we're not exposing it in the public API.
+	ClassDB::bind_method(D_METHOD("_set_enabled", "enabled"), &BTTask::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &BTTask::is_enabled);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "_set_enabled", "is_enabled");
 
 	GDVIRTUAL_BIND(_setup);
 	GDVIRTUAL_BIND(_enter);

--- a/bt/tasks/bt_task.h
+++ b/bt/tasks/bt_task.h
@@ -164,7 +164,7 @@ public:
 	}
 
 	_FORCE_INLINE_ int get_child_count() const { return data.children.size(); }
-	int get_child_count_excluding_comments() const;
+	int get_enabled_child_count() const;
 
 	void add_child(Ref<BTTask> p_child);
 	void add_child_at_index(Ref<BTTask> p_child, int p_idx);

--- a/bt/tasks/bt_task.h
+++ b/bt/tasks/bt_task.h
@@ -85,6 +85,7 @@ private:
 		Status status = FRESH;
 		double elapsed = 0.0;
 		bool display_collapsed = false;
+		bool enabled = true;
 #ifdef TOOLS_ENABLED
 		ObjectID behavior_tree_id;
 #endif
@@ -97,6 +98,9 @@ private:
 
 protected:
 	static void _bind_methods();
+
+	void _set_enabled(bool p_enabled) { data.enabled = p_enabled; }
+	void _emit_branch_changed();
 
 	virtual String _generate_name();
 	virtual void _setup() {}
@@ -121,6 +125,11 @@ public:
 #ifdef LIMBOAI_MODULE
 	virtual bool editor_can_reload_from_file() override { return false; }
 #endif // LIMBOAI_MODULE
+
+	_FORCE_INLINE_ bool is_enabled() const { return data.enabled; }
+	// Note: BTComment overrides set_enabled() to be always disabled.
+	virtual void set_enabled(bool p_enabled);
+	bool is_enabled_in_tree() const;
 
 	_FORCE_INLINE_ Node *get_agent() const { return data.agent; }
 	void set_agent(Node *p_agent) { data.agent = p_agent; }

--- a/bt/tasks/composites/bt_probability_selector.h
+++ b/bt/tasks/composites/bt_probability_selector.h
@@ -45,7 +45,7 @@ private:
 	_FORCE_INLINE_ double _get_total_weight() const {
 		double total = 0.0;
 		for (int i = 0; i < get_child_count(); i++) {
-			if (!IS_CLASS(get_child(i), BTComment)) {
+			if (get_child(i)->is_enabled()) {
 				total += _get_weight(i);
 			}
 		}

--- a/doc_classes/BTTask.xml
+++ b/doc_classes/BTTask.xml
@@ -108,10 +108,16 @@
 				Returns the number of child tasks.
 			</description>
 		</method>
-		<method name="get_child_count_excluding_comments" qualifiers="const">
+		<method name="get_child_count_excluding_comments" qualifiers="const" deprecated="Use [method get_enabled_child_count] instead.">
 			<return type="int" />
 			<description>
 				Returns the number of child tasks not counting [BTComment] tasks.
+			</description>
+		</method>
+		<method name="get_enabled_child_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of enabled child tasks. [BTComment] tasks and tasks that are disabled in the editor are not included in the count.
 			</description>
 		</method>
 		<method name="get_index" qualifiers="const">

--- a/doc_classes/BTTask.xml
+++ b/doc_classes/BTTask.xml
@@ -163,6 +163,12 @@
 				Returns [code]true[/code] if this task is a descendant of [param task]. In other words, this task must be a child of [param task] or one of its children or grandchildren.
 			</description>
 		</method>
+		<method name="is_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this task is enabled in the editor. If [code]false[/code], this task and its branch will not be instantiated at runtime, as if they never existed. [BTComment] always returns [code]false[/code].
+			</description>
+		</method>
 		<method name="is_root" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc_classes/BehaviorTree.xml
+++ b/doc_classes/BehaviorTree.xml
@@ -62,6 +62,12 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="branch_changed">
+			<param index="0" name="branch" type="BTTask" />
+			<description>
+				Emitted when a contained [BTTask] or its branch changes in a way that requires refreshing the entire branch. This signal is emitted only in the editor.
+			</description>
+		</signal>
 		<signal name="plan_changed">
 			<description>
 				Emitted when the [BlackboardPlan] changes.

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -561,6 +561,11 @@ void LimboAIEditor::_on_tree_rmb(const Vector2 &p_menu_pos) {
 	menu->set_item_disabled(menu->get_item_index(ACTION_EDIT_SCRIPT), task->get_script() == Variant());
 
 	menu->add_separator();
+	const Ref<Texture2D> &enabled_icon = task->is_enabled() ? theme_cache.checked_icon : theme_cache.unchecked_icon;
+	menu->add_icon_item(enabled_icon, TTR("Enabled"), ACTION_ENABLED);
+	menu->set_item_checked(ACTION_ENABLED, task->is_enabled());
+
+	menu->add_separator();
 	menu->add_icon_shortcut(theme_cache.cut_icon, LW_GET_SHORTCUT("limbo_ai/cut_task"), ACTION_CUT);
 	menu->add_icon_shortcut(theme_cache.copy_icon, LW_GET_SHORTCUT("limbo_ai/copy_task"), ACTION_COPY);
 	menu->add_icon_shortcut(theme_cache.paste_icon, LW_GET_SHORTCUT("limbo_ai/paste_task"), ACTION_PASTE);
@@ -603,6 +608,16 @@ void LimboAIEditor::_action_selected(int p_id) {
 			rename_dialog->popup_centered();
 			rename_edit->select_all();
 			rename_edit->grab_focus();
+		} break;
+		case ACTION_ENABLED: {
+			Ref<BTTask> task = task_tree->get_selected();
+			if (task.is_valid()) {
+				EditorUndoRedoManager *undo_redo = _new_undo_redo_action(TTR("Toggle enabled"));
+				undo_redo->add_do_method(task.ptr(), LW_NAME(_set_enabled), !task->is_enabled());
+				undo_redo->add_undo_method(task.ptr(), LW_NAME(_set_enabled), task->is_enabled());
+				undo_redo->commit_action();
+				_set_as_dirty(task_tree->get_bt(), true);
+			}
 		} break;
 		case ACTION_CHANGE_TYPE: {
 			change_type_palette->clear_filter();
@@ -1482,6 +1497,8 @@ void LimboAIEditor::_do_update_theme_item_cache() {
 	theme_cache.copy_icon = get_theme_icon(LW_NAME(ActionCopy), LW_NAME(EditorIcons));
 	theme_cache.paste_icon = get_theme_icon(LW_NAME(ActionPaste), LW_NAME(EditorIcons));
 	theme_cache.search_icon = get_theme_icon(LW_NAME(Search), LW_NAME(EditorIcons));
+	theme_cache.checked_icon = get_theme_icon("GuiChecked", LW_NAME(EditorIcons));
+	theme_cache.unchecked_icon = get_theme_icon("GuiUnchecked", LW_NAME(EditorIcons));
 
 	theme_cache.behavior_tree_icon = LimboUtility::get_singleton()->get_task_icon("BehaviorTree");
 	theme_cache.percent_icon = LimboUtility::get_singleton()->get_task_icon("LimboPercent");

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -82,6 +82,7 @@ private:
 		ACTION_CHANGE_TYPE,
 		ACTION_EDIT_SCRIPT,
 		ACTION_OPEN_DOC,
+		ACTION_ENABLED,
 		ACTION_CUT,
 		ACTION_COPY,
 		ACTION_PASTE,
@@ -139,6 +140,8 @@ private:
 		Ref<Texture2D> copy_icon;
 		Ref<Texture2D> paste_icon;
 		Ref<Texture2D> search_icon;
+		Ref<Texture2D> checked_icon;
+		Ref<Texture2D> unchecked_icon;
 	} theme_cache;
 
 	EditorPlugin *plugin;

--- a/editor/task_tree.h
+++ b/editor/task_tree.h
@@ -78,6 +78,7 @@ private:
 	void _on_item_collapsed(Object *p_obj);
 	void _on_item_mouse_selected(const Vector2 &p_pos, MouseButton p_button_index);
 	void _on_task_changed();
+	void _on_branch_changed(const Ref<BTTask> &p_branch);
 
 	Variant _get_drag_data_fw(const Point2 &p_point);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data) const;

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -45,6 +45,7 @@ LimboStringNames::LimboStringNames() {
 	BBString = SN("BBString");
 	behavior_tree_finished = SN("behavior_tree_finished");
 	bold = SN("bold");
+	branch_changed = SN("branch_changed");
 	button_down = SN("button_down");
 	button_up = SN("button_up");
 	call_deferred = SN("call_deferred");
@@ -133,6 +134,7 @@ LimboStringNames::LimboStringNames() {
 	Search = SN("Search");
 	separation = SN("separation");
 	set_custom_name = SN("set_custom_name");
+	_set_enabled = SN("_set_enabled");
 	set_root_task = SN("set_root_task");
 	set_v_scroll = SN("set_v_scroll");
 	set_visible = SN("set_visible");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -61,6 +61,7 @@ public:
 	StringName BBString;
 	StringName behavior_tree_finished;
 	StringName bold;
+	StringName branch_changed;
 	StringName button_down;
 	StringName button_up;
 	StringName call_deferred;
@@ -149,6 +150,7 @@ public:
 	StringName Search;
 	StringName separation;
 	StringName set_custom_name;
+	StringName _set_enabled;
 	StringName set_root_task;
 	StringName set_v_scroll;
 	StringName set_visible;


### PR DESCRIPTION
This PR introduces enabling-disabling behavior tree branches in the LimboAI editor. Any branch can be disabled in the editor; at runtime, it's not instantiated as if it never existed.

Deprecated `BTTask.get_child_count_excluding_comments()` - it's renamed to `get_enabled_child_count()`.

Resolves #270.

https://github.com/user-attachments/assets/40753f1b-98ad-415b-8505-fe5c098ead5e

