### PR TITLE
Feature: Make editor actions work with multi-selection

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -553,7 +553,7 @@ void LimboAIEditor::_on_tree_rmb(const Vector2 &p_menu_pos) {
 		return;
 	}
 
-	if (task_tree->selected_has_probability() && selected.size() == 1) {
+	if (selected.size() == 1 && task_tree->selected_has_probability()) {
 		menu->add_icon_item(theme_cache.percent_icon, TTR("Edit Probability"), ACTION_EDIT_PROBABILITY);
 	}
 	menu->add_icon_shortcut(theme_cache.rename_task_icon, LW_GET_SHORTCUT("limbo_ai/rename_task"), ACTION_RENAME);
@@ -612,7 +612,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 	switch (p_id) {
 		case ACTION_RENAME: {
 			Ref<BTTask> task = task_tree->get_selected();
-			if (!task.is_valid()) {
+			if (task.is_null()) {
 				return;
 			}
 			if (IS_CLASS(task, BTComment)) {
@@ -646,7 +646,7 @@ void LimboAIEditor::_action_selected(int p_id) {
 					group.remove_at(i);
 				}
 			}
-			EditorUndoRedoManager *undo_redo = _new_undo_redo_action(group_enabled ? TTR("Disable tasks") : TTR("Enable tasks"));
+			EditorUndoRedoManager *undo_redo = _new_undo_redo_action(group_enabled ? TTR("Disable BT tasks") : TTR("Enable BT tasks"));
 			for (const Ref<BTTask> &task : group) {
 				ERR_CONTINUE(task.is_null());
 				undo_redo->add_do_method(task.ptr(), LW_NAME(_set_enabled), !group_enabled);

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -630,27 +630,27 @@ void LimboAIEditor::_action_selected(int p_id) {
 			rename_edit->grab_focus();
 		} break;
 		case ACTION_ENABLED: {
-			Vector<Ref<BTTask>> toggled = task_tree->get_selected_tasks();
-			if (toggled.is_empty()) {
+			Vector<Ref<BTTask>> group = task_tree->get_selected_tasks();
+			if (group.is_empty()) {
 				return;
 			}
-			bool is_enabled = false;
-			for (const Ref<BTTask> &task : toggled) {
+			bool group_enabled = false;
+			for (const Ref<BTTask> &task : group) {
 				if (task->is_enabled()) {
-					is_enabled = true;
+					group_enabled = true;
 					break;
 				}
 			}
-			for (int i = toggled.size() - 1; i >= 0; i--) {
-				if (toggled[i]->is_enabled() != is_enabled) {
-					toggled.remove_at(i);
+			for (int i = group.size() - 1; i >= 0; i--) {
+				if (group[i]->is_enabled() != group_enabled) {
+					group.remove_at(i);
 				}
 			}
-			EditorUndoRedoManager *undo_redo = _new_undo_redo_action(is_enabled ? TTR("Disable tasks") : TTR("Enable tasks"));
-			for (const Ref<BTTask> &task : toggled) {
+			EditorUndoRedoManager *undo_redo = _new_undo_redo_action(group_enabled ? TTR("Disable tasks") : TTR("Enable tasks"));
+			for (const Ref<BTTask> &task : group) {
 				ERR_CONTINUE(task.is_null());
-				undo_redo->add_do_method(task.ptr(), LW_NAME(_set_enabled), !is_enabled);
-				undo_redo->add_undo_method(task.ptr(), LW_NAME(_set_enabled), is_enabled);
+				undo_redo->add_do_method(task.ptr(), LW_NAME(_set_enabled), !group_enabled);
+				undo_redo->add_undo_method(task.ptr(), LW_NAME(_set_enabled), group_enabled);
 			}
 			undo_redo->commit_action();
 			_set_as_dirty(task_tree->get_bt(), true);

--- a/editor/limbo_ai_editor_plugin.h
+++ b/editor/limbo_ai_editor_plugin.h
@@ -142,6 +142,7 @@ private:
 		Ref<Texture2D> search_icon;
 		Ref<Texture2D> checked_icon;
 		Ref<Texture2D> unchecked_icon;
+		Ref<Texture2D> indeterminate_icon;
 	} theme_cache;
 
 	EditorPlugin *plugin;
@@ -152,7 +153,7 @@ private:
 	bool updating_tabs = false;
 	bool request_update_tabs = false;
 	HashSet<Ref<BehaviorTree>> dirty;
-	Ref<BTTask> clipboard_task;
+	Vector<Ref<BTTask>> clipboard;
 
 	VBoxContainer *vbox;
 	PanelContainer *tab_bar_panel;

--- a/editor/task_tree.cpp
+++ b/editor/task_tree.cpp
@@ -208,14 +208,15 @@ void TaskTree::_on_branch_changed(const Ref<BTTask> &p_branch) {
 	if (!item) {
 		return;
 	}
-	bool was_selected = item->is_selected(0);
+	Vector<Ref<BTTask>> selection = get_selected_tasks();
 	TreeItem *parent = item->get_parent();
 	Ref<BTTask> task = item->get_metadata(0);
 	int index = item->get_index();
 	memdelete(item);
-	TreeItem *created = _create_tree(task, parent, index);
-	if (created && was_selected) {
-		created->select(0);
+	_create_tree(task, parent, index);
+	clear_selection();
+	for (const Ref<BTTask> &sel : selection) {
+		add_selection(sel);
 	}
 }
 


### PR DESCRIPTION
Make context editor actions work with multi-selection. Before this PR, multi-selection is useful only for drag and drop.

Resolves #299 among other things.


https://github.com/user-attachments/assets/22b840b9-de7c-4df4-ae1a-39719ae222c3

PS: 300 🙌