### PR TITLE
Fix `BlackboardPlan` mappings cleared on project export

### DIFF
--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -286,9 +286,15 @@ void BlackboardPlan::set_base_plan(const Ref<BlackboardPlan> &p_base) {
 	notify_property_list_changed();
 }
 
-void BlackboardPlan::set_parent_scope_plan_provider(const Callable &p_parent_scope_plan_provider) {
-	parent_scope_plan_provider = p_parent_scope_plan_provider;
+void BlackboardPlan::set_parent_scope_plan_provider(const Callable &p_provider_callable) {
+	parent_scope_plan_providers.push(p_provider_callable);
 	notify_property_list_changed();
+}
+
+bool BlackboardPlan::is_mapping_enabled() const {
+	const Callable &provider = parent_scope_plan_providers.get_most_recent_valid();
+	Ref<BlackboardPlan> parent_scope = provider.call();
+	return parent_scope.is_valid();
 }
 
 bool BlackboardPlan::has_mapping(const StringName &p_name) const {

--- a/blackboard/callable_fallback_chain.cpp
+++ b/blackboard/callable_fallback_chain.cpp
@@ -14,24 +14,17 @@
 void CallableFallbackChain::push(const Callable &p_callable) {
 	ERR_FAIL_COND(p_callable.is_null());
 
-	List<Callable>::Element *found = nullptr;
 	List<Callable>::Element *it = chain.back();
 	while (it) {
 		List<Callable>::Element *cur = it;
 		it = it->prev();
 
-		if (cur->get() == p_callable) {
-			found = cur;
-		} else if (cur->get().is_null()) {
+		if (cur->get().is_null() || cur->get() == p_callable) {
 			cur->erase();
 		}
 	}
 
-	if (found) {
-		found->transfer_to_back(&chain);
-	} else {
-		chain.push_back(p_callable);
-	}
+	chain.push_back(p_callable);
 }
 
 Callable CallableFallbackChain::get_most_recent_valid() const {

--- a/blackboard/callable_fallback_chain.cpp
+++ b/blackboard/callable_fallback_chain.cpp
@@ -1,0 +1,28 @@
+/**
+ * callable_fallback_chain.cpp
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#include "callable_fallback_chain.h"
+
+void CallableFallbackChain::push(const Callable &p_callable) {
+	chain.push_front(p_callable);
+}
+
+Callable CallableFallbackChain::get_most_recent_valid() const {
+	while (!chain.is_empty()) {
+		const Callable &callable = chain.front()->get();
+		if (callable.is_valid()) {
+			return callable;
+		} else {
+			chain.pop_front();
+		}
+	}
+	return Callable();
+}

--- a/blackboard/callable_fallback_chain.cpp
+++ b/blackboard/callable_fallback_chain.cpp
@@ -12,16 +12,35 @@
 #include "callable_fallback_chain.h"
 
 void CallableFallbackChain::push(const Callable &p_callable) {
-	chain.push_front(p_callable);
+	ERR_FAIL_COND(p_callable.is_null());
+
+	List<Callable>::Element *found = nullptr;
+	List<Callable>::Element *it = chain.back();
+	while (it) {
+		List<Callable>::Element *cur = it;
+		it = it->prev();
+
+		if (cur->get() == p_callable) {
+			found = cur;
+		} else if (cur->get().is_null()) {
+			cur->erase();
+		}
+	}
+
+	if (found) {
+		found->transfer_to_back(&chain);
+	} else {
+		chain.push_back(p_callable);
+	}
 }
 
 Callable CallableFallbackChain::get_most_recent_valid() const {
 	while (!chain.is_empty()) {
-		const Callable &callable = chain.front()->get();
+		const Callable &callable = chain.back()->get();
 		if (callable.is_valid()) {
 			return callable;
 		} else {
-			chain.pop_front();
+			chain.pop_back();
 		}
 	}
 	return Callable();

--- a/blackboard/callable_fallback_chain.h
+++ b/blackboard/callable_fallback_chain.h
@@ -1,0 +1,26 @@
+/**
+ * callable_fallback_chain.h
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+#ifndef CALLABLE_FALLBACK_CHAIN_H
+#define CALLABLE_FALLBACK_CHAIN_H
+
+#include "core/templates/list.h"
+#include "core/variant/callable.h"
+
+class CallableFallbackChain {
+private:
+	mutable List<Callable> chain;
+
+public:
+	void push(const Callable &p_callable);
+	Callable get_most_recent_valid() const;
+};
+
+#endif // CALLABLE_FALLBACK_CHAIN_H

--- a/blackboard/callable_fallback_chain.h
+++ b/blackboard/callable_fallback_chain.h
@@ -11,8 +11,16 @@
 #ifndef CALLABLE_FALLBACK_CHAIN_H
 #define CALLABLE_FALLBACK_CHAIN_H
 
+#ifdef LIMBOAI_MODULE
 #include "core/templates/list.h"
 #include "core/variant/callable.h"
+#endif // LIMBOAI_MODULE
+
+#ifdef LIMBOAI_GDEXTENSION
+#include <godot_cpp/templates/list.hpp>
+#include <godot_cpp/variant/callable.hpp>
+using namespace godot;
+#endif // LIMBOAI_GDEXTENSION
 
 class CallableFallbackChain {
 private:

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -11,9 +11,8 @@
 
 #include "limbo_state.h"
 
-#include "../compat/limbo_compat.h"
-
 #ifdef LIMBOAI_MODULE
+#include "core/config/engine.h"
 #endif // LIMBOAI_MODULE
 
 #ifdef LIMBOAI_GDEXTENSION
@@ -21,6 +20,10 @@
 #endif
 
 void LimboState::set_blackboard_plan(const Ref<BlackboardPlan> &p_plan) {
+	if (blackboard_plan == p_plan) {
+		return;
+	}
+
 	blackboard_plan = p_plan;
 
 	if (Engine::get_singleton()->is_editor_hint() && blackboard_plan.is_valid()) {


### PR DESCRIPTION
Fix a rare issue when `BlackboardPlan` mappings are cleared on project export if such a plan is currently open in the inspector.

Resolves #307