### PR TITLE
Make EVENT_FINISHED unique

### DIFF
--- a/doc_classes/LimboState.xml
+++ b/doc_classes/LimboState.xml
@@ -114,6 +114,7 @@
 	<members>
 		<member name="EVENT_FINISHED" type="StringName" setter="" getter="event_finished">
 			A commonly used event that indicates that the state has finished its work.
+			This is unique per state.
 		</member>
 		<member name="agent" type="Node" setter="set_agent" getter="get_agent">
 			An agent associated with the state, assigned during initialization.

--- a/hsm/limbo_hsm.cpp
+++ b/hsm/limbo_hsm.cpp
@@ -221,7 +221,7 @@ bool LimboHSM::_dispatch(const StringName &p_event, const Variant &p_cargo) {
 		}
 	}
 
-	if (!event_consumed && p_event == LW_NAME(EVENT_FINISHED) && !(get_parent() && get_parent()->is_class("LimboState"))) {
+	if (!event_consumed && p_event == EVENT_FINISHED && !(get_parent() && get_parent()->is_class("LimboState"))) {
 		_exit();
 	}
 

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -235,6 +235,7 @@ void LimboState::_bind_methods() {
 }
 
 LimboState::LimboState() {
+	EVENT_FINISHED = StringName("finished_" + itos(get_instance_id()));
 	agent = nullptr;
 	active = false;
 	blackboard = Ref<Blackboard>(memnew(Blackboard));

--- a/hsm/limbo_state.h
+++ b/hsm/limbo_state.h
@@ -34,6 +34,7 @@ class LimboState : public Node {
 	GDCLASS(LimboState, Node);
 
 private:
+	StringName EVENT_FINISHED;
 	bool active;
 	Ref<BlackboardPlan> blackboard_plan;
 	Node *agent;
@@ -88,7 +89,7 @@ public:
 	void add_event_handler(const StringName &p_event, const Callable &p_handler);
 	bool dispatch(const StringName &p_event, const Variant &p_cargo = Variant());
 
-	_FORCE_INLINE_ StringName event_finished() const { return LW_NAME(EVENT_FINISHED); }
+	_FORCE_INLINE_ StringName event_finished() const { return EVENT_FINISHED; }
 	LimboState *get_root() const;
 	_FORCE_INLINE_ bool is_root() const { return !(get_parent() && IS_CLASS(get_parent(), LimboState)); }
 	_FORCE_INLINE_ bool is_active() const { return active; }

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -64,7 +64,6 @@ LimboStringNames::LimboStringNames() {
 	entered = SN("entered");
 	error_value = SN("error_value");
 	EVENT_FAILURE = SN("failure");
-	EVENT_FINISHED = SN("finished");
 	EVENT_SUCCESS = SN("success");
 	exited = SN("exited");
 	ExternalLink = SN("ExternalLink");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -83,7 +83,6 @@ public:
 	StringName entered;
 	StringName error_value;
 	StringName EVENT_FAILURE;
-	StringName EVENT_FINISHED;
 	StringName EVENT_SUCCESS;
 	StringName exited;
 	StringName ExternalLink;


### PR DESCRIPTION
Uses `get_instance_id()` to distinguish "EVENT_FINISHED"