### PR TITLE
GHA: Build nothreads versions for Web GDExtension

### DIFF
--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -113,18 +113,36 @@ jobs:
             arch: universal
             should-build: true
 
-          - name: 🌐 Web (wasm32, release)
+          - name: 🌐 Web (wasm32, threads, release)
             runner: ubuntu-22.04
             platform: web
             target: template_release
             arch: wasm32
+            threads: yes
             should-build: ${{ !inputs.test-build }}
 
-          - name: 🌐 Web (wasm32, debug)
+          - name: 🌐 Web (wasm32, threads, debug)
             runner: ubuntu-22.04
             platform: web
             target: editor
             arch: wasm32
+            threads: yes
+            should-build: ${{ !inputs.test-build }}
+
+          - name: 🌐 Web (wasm32, nothreads, release)
+            runner: ubuntu-22.04
+            platform: web
+            target: template_release
+            arch: wasm32
+            threads: no
+            should-build: ${{ !inputs.test-build }}
+
+          - name: 🌐 Web (wasm32, nothreads, debug)
+            runner: ubuntu-22.04
+            platform: web
+            target: editor
+            arch: wasm32
+            threads: no
             should-build: ${{ !inputs.test-build }}
 
           - name: 🤖 Android (arm64, release)
@@ -217,7 +235,7 @@ jobs:
           - { opts: { should-build: false } }
 
     env:
-      BIN: liblimboai.${{matrix.opts.platform}}.${{matrix.opts.target}}.${{matrix.opts.arch}}
+      BIN: liblimboai.${{matrix.opts.platform}}.${{matrix.opts.target}}.${{matrix.opts.arch}}${{ matrix.opts.threads == 'no' && '.nothreads' || '' }}
 
     steps:
       - name: Clone LimboAI module
@@ -317,7 +335,7 @@ jobs:
           DEBUG_FLAGS: ${{ inputs.debug-symbols && 'debug_symbols=yes symbols_visibility=visible' || 'debug_symbols=no' }}
         run: |
           PATH=${GITHUB_WORKSPACE}/buildroot/bin:$PATH
-          scons platform=${{matrix.opts.platform}} target=${{matrix.opts.target}} arch=${{matrix.opts.arch}} ${{env.DEBUG_FLAGS}} ${{matrix.opts.scons-flags}} ${{env.SCONSFLAGS}}
+          scons platform=${{matrix.opts.platform}} target=${{matrix.opts.target}} arch=${{matrix.opts.arch}} ${{ matrix.opts.threads == 'no' && 'threads=no' || '' }} ${{env.DEBUG_FLAGS}} ${{matrix.opts.scons-flags}} ${{env.SCONSFLAGS}}
 
       - name: Prepare artifact
         shell: bash
@@ -336,7 +354,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         env:
-          NAME: tmp-gdextension.${{matrix.opts.platform}}.${{matrix.opts.target}}.${{matrix.opts.arch}}
+          NAME: tmp-gdextension.${{matrix.opts.platform}}.${{matrix.opts.target}}.${{matrix.opts.arch}}${{ matrix.opts.threads == 'no' && '.nothreads' || '' }}
         with:
           name: ${{ env.NAME }}
           path: out/*

--- a/gdextension/limboai.gdextension
+++ b/gdextension/limboai.gdextension
@@ -29,8 +29,10 @@ ios.debug.arm64 = "res://addons/limboai/bin/liblimboai.ios.editor.arm64.dylib"
 ios.release.arm64 = "res://addons/limboai/bin/liblimboai.ios.template_release.arm64.dylib"
 ios.debug.simulator = "res://addons/limboai/bin/liblimboai.ios.editor.universal.dylib"
 ios.release.simulator = "res://addons/limboai/bin/liblimboai.ios.template_release.universal.dylib"
-web.debug.wasm32 = "res://addons/limboai/bin/liblimboai.web.editor.wasm32.wasm"
-web.release.wasm32 = "res://addons/limboai/bin/liblimboai.web.template_release.wasm32.wasm"
+web.debug.wasm32 = "res://addons/limboai/bin/liblimboai.web.editor.wasm32.nothreads.wasm"
+web.release.wasm32 = "res://addons/limboai/bin/liblimboai.web.template_release.wasm32.nothreads.wasm"
+web.debug.threads.wasm32 = "res://addons/limboai/bin/liblimboai.web.editor.wasm32.wasm"
+web.release.threads.wasm32 = "res://addons/limboai/bin/liblimboai.web.template_release.wasm32.wasm"
 
 [icons]
 


### PR DESCRIPTION
* Provide wasm `threads=no` builds for GDExtension variant.
* Fix #283.