### PR TITLE
Ignore code coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ bin
 *.files
 *.includes
 *.idb
+*.gcno
+*.gcda
 
 # Gprof output
 gmon.out


### PR DESCRIPTION
The `.gcno` are generated when compiling LimboAI as a module and when code coverage is enabled (i.e. `use_coverage=yes`).

The `.gcda` are generated at runtime after running Godot.