### PR TITLE
Support Godot 4.5 as GDExtension 

### DIFF
--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -147,8 +147,8 @@ LimboStringNames::LimboStringNames() {
 	visibility_changed = StringName("visibility_changed");
 	window_visibility_changed = StringName("window_visibility_changed");
 
-	repeat_forever.append_utf8("Repeat ∞");
-	output_var_prefix.append_utf8("➜");
+	repeat_forever = String::utf8("Repeat ∞");
+	output_var_prefix = String::utf8("➜");
 
 	node_pp = NodePath("..");
 }


### PR DESCRIPTION
Depends on #311

Untested. Just got it to compile -- I assume the build probably works as expected unless the bindings crash somewhere since they don't seem to be properly updated yet.

~~This patch is probably temporary since once the bindings are updated, there's a chance this patch may no longer work.~~