### PR TITLE
BTPlayer: Defer BT initialization until active and local scene root is ready

### DIFF
--- a/bt/bt_player.h
+++ b/bt/bt_player.h
@@ -48,9 +48,10 @@ private:
 
 	Ref<BTInstance> bt_instance;
 
-	void _instantiate_bt();
+	void _try_initialize();
+	void _initialize_blackboard();
+	void _initialize_bt();
 	void _update_blackboard_plan();
-	void _initialize();
 	_FORCE_INLINE_ Node *_get_scene_root() const { return scene_root_hint ? scene_root_hint : get_owner(); }
 
 protected:

--- a/compat/node.h
+++ b/compat/node.h
@@ -1,0 +1,24 @@
+/**
+ * compat/node.h
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#pragma once
+
+#ifdef LIMBOAI_MODULE
+
+#define IS_NODE_READY(m_node) (m_node->is_ready())
+
+#endif // LIMBOAI_MODULE
+
+#ifdef LIMBOAI_GDEXTENSION
+
+#define IS_NODE_READY(m_node) (m_node->is_node_ready())
+
+#endif // LIMBOAI_GDEXTENSION

--- a/doc_classes/BTPlayer.xml
+++ b/doc_classes/BTPlayer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[BTPlayer] node is used to instantiate and play [BehaviorTree] resources at runtime. During initialization, the behavior tree instance is given references to the agent, the [member blackboard], and the current scene root. The agent can be specified by the [member agent_node] property (defaults to the BTPlayer's parent node).
+		The [member behavior_tree] is only initialized when [member active] is [code]true[/code] and the agent's local scene root node is ready. If [BTPlayer] becomes active before the scene root node is ready, initialization is delayed until then. When [member active] is [code]false[/code], initialization is postponed until activation.
 		For an introduction to behavior trees, see [BehaviorTree].
 	</description>
 	<tutorials>
@@ -46,7 +47,7 @@
 	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="get_active" default="true">
-			If [code]true[/code], the behavior tree will be executed during update.
+			When [code]true[/code], the behavior tree is executed during updates. [BTPlayer] initializes its [BehaviorTree] instance the first time it becomes active, but only after the agent's local scene root node is ready. If the agent becomes active before the root is ready, initialization is delayed until it is. When [code]false[/code], the behavior tree is not executed and initialization is postponed until activation.
 		</member>
 		<member name="agent_node" type="NodePath" setter="set_agent_node" getter="get_agent_node" default="NodePath(&quot;..&quot;)">
 			Path to the node that will be used as the agent. Setting it after instantiation will have no effect.

--- a/tests/lambda_callable.h
+++ b/tests/lambda_callable.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <functional>
+
+#include "core/templates/hashfuncs.h"
+#include "core/variant/callable.h"
+#include "core/variant/variant.h"
+
+// Used in LimboAI testing to inline signal handlers (for now).
+// It only supports zero arguments!
+class LambdaCallable : public CallableCustom {
+private:
+	std::function<void()> lambda_func;
+	uint32_t hash_value;
+
+public:
+	LambdaCallable(std::function<void()> func) :
+			lambda_func(func) {
+		hash_value = hash_murmur3_one_64((uint64_t)this);
+	}
+
+	virtual uint32_t hash() const override {
+		return hash_value;
+	}
+
+	virtual String get_as_text() const override {
+		return "LambdaCallable";
+	}
+
+	virtual CompareEqualFunc get_compare_equal_func() const override {
+		return [](const CallableCustom *a, const CallableCustom *b) { return a == b; };
+	}
+
+	virtual CompareLessFunc get_compare_less_func() const override {
+		return [](const CallableCustom *a, const CallableCustom *b) { return a < b; };
+	}
+
+	virtual ObjectID get_object() const override {
+		return ObjectID();
+	}
+
+	virtual bool is_valid() const override {
+		return lambda_func != nullptr; // Critical: Override is_valid()
+	}
+
+	virtual int get_argument_count(bool &r_is_valid) const override {
+		r_is_valid = true;
+		return 0; // Zero arguments only
+	}
+
+	virtual void call(const Variant **p_arguments, int p_argcount,
+			Variant &r_return_value, Callable::CallError &r_call_error) const override {
+		if (p_argcount != 0) {
+			r_call_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+			r_call_error.expected = 0;
+			return;
+		}
+
+		if (lambda_func) {
+			lambda_func();
+			r_call_error.error = Callable::CallError::CALL_OK;
+		} else {
+			r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+		}
+	}
+};

--- a/tests/test_bt_player.h
+++ b/tests/test_bt_player.h
@@ -1,0 +1,204 @@
+/**
+ * test_bt_player.h
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#pragma once
+
+#include "lambda_callable.h"
+#include "limbo_test.h"
+
+#include "modules/limboai/bt/behavior_tree.h"
+#include "modules/limboai/bt/bt_player.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+
+namespace TestBTPlayer {
+
+TEST_CASE("[Modules][LimboAI] BTPlayer basic functionality") {
+	BTPlayer *bt_player = memnew(BTPlayer);
+
+	SUBCASE("Initial state") {
+		CHECK(bt_player->get_behavior_tree().is_null());
+		CHECK(bt_player->get_bt_instance().is_null());
+		CHECK(bt_player->get_blackboard().is_valid());
+		CHECK(bt_player->get_active() == true);
+		CHECK(bt_player->get_update_mode() == BTPlayer::PHYSICS);
+	}
+
+	SUBCASE("Property setters and getters") {
+		// Test update mode
+		bt_player->set_update_mode(BTPlayer::IDLE);
+		CHECK(bt_player->get_update_mode() == BTPlayer::IDLE);
+
+		bt_player->set_update_mode(BTPlayer::MANUAL);
+		CHECK(bt_player->get_update_mode() == BTPlayer::MANUAL);
+
+		// Test active state
+		bt_player->set_active(false);
+		CHECK(bt_player->get_active() == false);
+
+		bt_player->set_active(true);
+		CHECK(bt_player->get_active() == true);
+
+		// Test agent node path
+		NodePath test_path("TestAgent");
+		bt_player->set_agent_node(test_path);
+		CHECK(bt_player->get_agent_node() == test_path);
+	}
+
+	SUBCASE("Behavior tree setting without scene") {
+		Ref<BehaviorTree> bt = memnew(BehaviorTree);
+		bt_player->set_behavior_tree(bt);
+		CHECK(bt_player->get_behavior_tree() == bt);
+		CHECK(bt_player->get_bt_instance().is_null()); // not intantiated until scene root is ready
+	}
+
+	SUBCASE("Null behavior tree handling") {
+		bt_player->set_behavior_tree(Ref<BehaviorTree>());
+		CHECK(bt_player->get_behavior_tree().is_null());
+		CHECK(bt_player->get_bt_instance().is_null());
+	}
+
+	SUBCASE("Error handling with null bt_instance") {
+		CHECK(bt_player->get_bt_instance().is_null());
+		ERR_PRINT_OFF;
+		bt_player->update(0.01666); // Should not crash
+		bt_player->restart(); // Should fail gracefully
+		ERR_PRINT_ON;
+	}
+
+	memdelete(bt_player);
+}
+
+TEST_CASE("[SceneTree][LimboAI] BTPlayer lifecycle scenarios") {
+	// Setup.
+	Node *scene_root = memnew(Node);
+
+	Ref<BehaviorTree> bt = memnew(BehaviorTree);
+
+	Ref<BTAction> test_action = memnew(BTAction);
+	bt->set_root_task(test_action);
+
+	BTPlayer *bt_player = memnew(BTPlayer);
+
+	SUBCASE("Scenario 1: Typical scene load") {
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_behavior_tree(bt);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		scene_root->add_child(bt_player);
+		bt_player->set_owner(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// BTPlayer should NOT initialize in NOTIFICATION_READY, but wait for scene root.
+		bt_player->connect("ready",
+				memnew(LambdaCallable([bt_player]() {
+					CHECK(bt_player->get_bt_instance().is_null());
+				})));
+
+		// NOTE: Automatic initialization should happen after scene root propagates NOTIFICATION_READY.
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+		CHECK(bt_player->get_bt_instance().is_valid());
+	}
+
+	SUBCASE("Scenario 2: With scene root hint") {
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_behavior_tree(bt);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// Setting scene root hint works as alternative to setting owner.
+		Node *alt_root = memnew(Node);
+		bt_player->set_scene_root_hint(alt_root);
+		alt_root->add_child(bt_player);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// BTPlayer should NOT initialize in NOTIFICATION_READY, but wait for scene root.
+		bt_player->connect("ready",
+				memnew(LambdaCallable([bt_player]() {
+					CHECK(bt_player->get_bt_instance().is_null());
+				})));
+
+		scene_root->add_child(alt_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// NOTE: Automatic initialization should happen after alt_scene_root propagates NOTIFICATION_READY.
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+		CHECK(bt_player->get_bt_instance().is_valid());
+
+		CHECK(bt_player->get_bt_instance()->get_root_task()->get_scene_root() == alt_root);
+	}
+
+	SUBCASE("Scenario 3: Setting behavior tree after NOTIFICATION_READY.") {
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		scene_root->add_child(bt_player);
+		bt_player->set_owner(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// BTPlayer should NOT initialize in NOTIFICATION_READY, but wait for scene root and behavior tree to be set.
+		bt_player->connect("ready",
+				memnew(LambdaCallable([bt_player]() {
+					CHECK(bt_player->get_bt_instance().is_null());
+				})));
+
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null()); // behavior tree is not set yet
+
+		bt_player->set_behavior_tree(bt); // should initialize here
+		CHECK(bt_player->get_bt_instance().is_valid());
+	}
+
+	SUBCASE("Scenario 4: Adding BTPlayer after scene root (unlikely edge case)") {
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_behavior_tree(bt);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_scene_root_hint(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		scene_root->add_child(bt_player);
+		CHECK(bt_player->get_bt_instance().is_valid());
+	}
+
+	// Clean up
+	scene_root->queue_free();
+}
+
+TEST_CASE("[SceneTree][LimboAI] BTPlayer blackboard persistence") {
+	// Setup.
+	Node *scene_root = memnew(Node);
+
+	Ref<BehaviorTree> bt = memnew(BehaviorTree);
+	Ref<BTAction> test_action = memnew(BTAction);
+	bt->set_root_task(test_action);
+
+	BTPlayer *bt_player = memnew(BTPlayer);
+
+	SUBCASE("Variables set before initialization should persist through initialization") {
+		bt_player->get_blackboard()->set_var("test_variable", 123);
+
+		bt_player->set_behavior_tree(bt);
+		scene_root->add_child(bt_player);
+		bt_player->set_owner(scene_root);
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+
+		CHECK(bt_player->get_bt_instance()->get_blackboard() == bt_player->get_blackboard());
+		CHECK(bt_player->get_bt_instance()->get_blackboard()->get_var("test_variable") == Variant(123));
+	}
+
+	// Clean up
+	scene_root->queue_free();
+}
+
+} // namespace TestBTPlayer

--- a/tests/test_bt_player.h
+++ b/tests/test_bt_player.h
@@ -171,6 +171,32 @@ TEST_CASE("[SceneTree][LimboAI] BTPlayer lifecycle scenarios") {
 		CHECK(bt_player->get_bt_instance().is_valid());
 	}
 
+	SUBCASE("Scenario 5: Activate BTPlayer after NOTIFICATION_READY") {
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_behavior_tree(bt);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_active(false);
+
+		scene_root->add_child(bt_player);
+		bt_player->set_owner(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		// BTPlayer should NOT initialize in NOTIFICATION_READY
+		bt_player->connect("ready",
+				memnew(LambdaCallable([bt_player]() {
+					CHECK(bt_player->get_bt_instance().is_null());
+				})));
+
+		// NOTE: Initialization should happen after first activation.
+		SceneTree::get_singleton()->get_root()->add_child(scene_root);
+		CHECK(bt_player->get_bt_instance().is_null());
+
+		bt_player->set_active(true);
+		CHECK(bt_player->get_bt_instance().is_valid());
+	}
+
 	// Clean up
 	scene_root->queue_free();
 }

--- a/util/limbo_string_names.cpp
+++ b/util/limbo_string_names.cpp
@@ -15,6 +15,7 @@ LimboStringNames *LimboStringNames::singleton = nullptr;
 
 LimboStringNames::LimboStringNames() {
 	_generate_name = StringName("_generate_name");
+	_initialize_bt = StringName("_initialize_bt");
 	_param_type = StringName("_param_type");
 	_replace_task = StringName("_replace_task");
 	_update_task_tree = StringName("_update_task_tree");
@@ -107,6 +108,7 @@ LimboStringNames::LimboStringNames() {
 	pressed = StringName("pressed");
 	probability_clicked = StringName("probability_clicked");
 	property_changed = StringName("property_changed");
+	ready = StringName("ready");
 	Reload = StringName("Reload");
 	Remove = StringName("Remove");
 	remove_child = StringName("remove_child");

--- a/util/limbo_string_names.h
+++ b/util/limbo_string_names.h
@@ -42,6 +42,7 @@ public:
 	_FORCE_INLINE_ static LimboStringNames *get_singleton() { return singleton; }
 
 	StringName _generate_name;
+	StringName _initialize_bt;
 	StringName _param_type;
 	StringName _replace_task;
 	StringName _update_task_tree;
@@ -134,6 +135,7 @@ public:
 	StringName pressed;
 	StringName probability_clicked;
 	StringName property_changed;
+	StringName ready;
 	StringName Reload;
 	StringName remove_child;
 	StringName Remove;


### PR DESCRIPTION
This PR refactors `BTPlayer` automatic initialization to wait for the agent's scene root to be ready. Behavior trees are often dependent on agent scene, so delaying automatic initialization makes some sense.

The behavior tree is initialized when `active` is `true` and the agent's local scene root node is ready. If `BTPlayer` becomes active before the scene root node is ready, initialization is delayed until then. When `active` is `false`, initialization is postponed until activation.

- Also this PR adds tests for `BTPlayer`.
- Supersedes #356 
- Closes #342 
