### PR TITLE
GHA: Pin Godot version in test builds to 4.5 for module and 4.4 for extension

### DIFF
--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -26,8 +26,8 @@ concurrency:
 
 # Global Settings.
 env:
-  GODOT_REF: "master"
-  GODOT_CPP_REF: "master"
+  GODOT_REF: "4.5-stable"
+  GODOT_CPP_REF: "godot-4.4-stable"
 
 jobs:
   unit-tests:

--- a/util/limbo_utility.cpp
+++ b/util/limbo_utility.cpp
@@ -398,11 +398,6 @@ String LimboUtility::get_property_hint_text(PropertyHint p_hint) const {
 		case PROPERTY_HINT_ONESHOT: {
 			return "ONESHOT";
 		}
-#ifdef LIMBOAI_MODULE
-		case PROPERTY_HINT_NO_NODEPATH: {
-			return "NO_NODEPATH";
-		}
-#endif // ! LIMBOAI_MODULE
 		case PROPERTY_HINT_LOCALE_ID: {
 			return "LOCALE_ID";
 		}
@@ -421,6 +416,10 @@ String LimboUtility::get_property_hint_text(PropertyHint p_hint) const {
 		case PROPERTY_HINT_LAYERS_AVOIDANCE: {
 			return "LAYERS_AVOIDANCE";
 		}
+#ifdef LIMBOAI_MODULE
+		case PROPERTY_HINT_NO_NODEPATH: {
+			return "NO_NODEPATH";
+		}
 		case PROPERTY_HINT_GROUP_ENABLE: {
 			return "GROUP_ENABLE";
 		}
@@ -430,6 +429,7 @@ String LimboUtility::get_property_hint_text(PropertyHint p_hint) const {
 		case PROPERTY_HINT_FILE_PATH: {
 			return "FILE_PATH";
 		}
+#endif // ! LIMBOAI_MODULE
 		case PROPERTY_HINT_MAX: {
 			return "MAX";
 		}


### PR DESCRIPTION
We reached 4.5 stable, and this PR pins CI workflow to use 4.5 for module, and 4.4 for GDExtension.