### PR TITLE
[GDExtension] Fix 4.5 `add_property_info()` warning

### DIFF
--- a/compat/project_settings.cpp
+++ b/compat/project_settings.cpp
@@ -38,7 +38,6 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 	dic_info["class_name"] = p_info.class_name;
 	dic_info["hint"] = p_info.hint;
 	dic_info["hint_string"] = p_info.hint_string;
-	dic_info["usage"] = p_info.usage;
 
 	ProjectSettings::get_singleton()->add_property_info(dic_info);
 	return ret;

--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -51,6 +51,7 @@
 #endif // LIMBOAI_MODULE
 
 #ifdef LIMBOAI_GDEXTENSION
+#include "godot_cpp/variant/dictionary.hpp"
 #include <godot_cpp/classes/button_group.hpp>
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/dir_access.hpp>
@@ -66,6 +67,7 @@
 #include <godot_cpp/classes/script.hpp>
 #include <godot_cpp/classes/script_editor.hpp>
 #include <godot_cpp/classes/v_separator.hpp>
+
 using namespace godot;
 #endif // LIMBOAI_GDEXTENSION
 
@@ -1688,11 +1690,11 @@ LimboAIEditor::LimboAIEditor() {
 	EDITOR_SETTINGS()->add_property_hint(PropertyInfo(Variant::INT, "limbo_ai/editor/layout", PROPERTY_HINT_ENUM, "Classic:0,Widescreen Optimized:1"));
 	EDITOR_SETTINGS()->set_restart_if_changed("limbo_ai/editor/layout", true);
 #elif LIMBOAI_GDEXTENSION
-	PropertyInfo pinfo;
-	pinfo.name = "limbo_ai/editor/layout";
-	pinfo.type = Variant::INT;
-	pinfo.hint = PROPERTY_HINT_ENUM;
-	pinfo.hint_string = "Classic:0,Widescreen Optimized:1";
+	Dictionary pinfo;
+	pinfo["name"] = "limbo_ai/editor/layout";
+	pinfo["type"] = Variant::INT;
+	pinfo["hint"] = PROPERTY_HINT_ENUM;
+	pinfo["hint_string"] = "Classic:0,Widescreen Optimized:1";
 	EDITOR_SETTINGS()->add_property_info(pinfo);
 #endif
 


### PR DESCRIPTION
Trying to upgrade my own project to 4.5, having warnings below.
<img width="847" height="70" alt="image" src="https://github.com/user-attachments/assets/6ebd52d5-66f0-42be-ad80-c0bdcddc01f0" />
- `add_property_info()` in project setting is easy to fix.
- `add_property_info()` in project setting in EditorSetting is caused by an implicit conversion using a Dictionary operator.