### PR TITLE
Editor: Fix crash on clicking Create button in a banner

### DIFF
--- a/editor/limbo_ai_editor_plugin.cpp
+++ b/editor/limbo_ai_editor_plugin.cpp
@@ -1525,7 +1525,7 @@ void LimboAIEditor::_update_banners() {
 		if (banners->get_child(i)->has_meta(LW_NAME(managed))) {
 			Node *banner = banners->get_child(i);
 			banners->remove_child(banner);
-			memfree(banner);
+			banner->queue_free();
 		}
 	}
 


### PR DESCRIPTION
memfree() leads to memory corruption here, even that the node is fully removed from the SceneTree. I haven't traced it fully. Replacing with queue_free() resolved the issue.
- Resolves #348