### PR TITLE
Plan editor: Add selection, copy, paste, remove

### DIFF
--- a/editor/blackboard_plan_editor.h
+++ b/editor/blackboard_plan_editor.h
@@ -52,6 +52,9 @@ private:
 private:
 	struct ThemeCache {
 		Ref<Texture2D> grab_icon;
+		Ref<Texture2D> checked_icon;
+		Ref<Texture2D> unchecked_icon;
+		Ref<Texture2D> indeterminate_icon;
 		Ref<StyleBoxFlat> odd_style;
 		Ref<StyleBoxFlat> even_style;
 		Ref<StyleBoxFlat> header_style;
@@ -82,6 +85,7 @@ private:
 	ScrollContainer *scroll_container;
 	PopupMenu *type_menu;
 	PopupMenu *hint_menu;
+	Button *mass_select_button;
 
 	LineEdit *_get_name_edit(int p_row_index) const;
 
@@ -105,6 +109,7 @@ private:
 
 	void _end_selection();
 	void _update_tools();
+	void _mass_select_pressed();
 
 	void _drag_button_down(Control *p_row);
 	void _drag_button_up();


### PR DESCRIPTION
Adds selection, copy-paste functionality to Blackboard Plan editor:

<img width="1020" height="756" alt="Screenshot 2025-10-04 at 15 01 02" src="https://github.com/user-attachments/assets/9820707c-d3cd-44dc-9fde-a1ea429e63e2" />

Potential future improvements: undo-redo support, import variables, templates.