### PR TITLE
POC for parallel state

### DIFF
--- a/hsm/limbo_parallel_state.cpp
+++ b/hsm/limbo_parallel_state.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "limbo_parallel_state.h"
-//#include "limbo_hsm.h"
 
 VARIANT_ENUM_CAST(LimboParallelState::UpdateMode);
 

--- a/hsm/limbo_parallel_state.cpp
+++ b/hsm/limbo_parallel_state.cpp
@@ -89,7 +89,6 @@ LimboState *LimboParallelState::get_leaf_state() const {
 	return const_cast<LimboParallelState *>(this);
 }
 
-
 bool LimboParallelState::_dispatch(const StringName &p_event, const Variant &p_cargo) {
 	ERR_FAIL_COND_V(p_event == StringName(), false);
 

--- a/hsm/limbo_parallel_state.cpp
+++ b/hsm/limbo_parallel_state.cpp
@@ -1,0 +1,220 @@
+/**
+ * limbo_parallel_state.cpp
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#include "limbo_parallel_state.h"
+//#include "limbo_hsm.h"
+
+VARIANT_ENUM_CAST(LimboParallelState::UpdateMode);
+
+void LimboParallelState::set_active(bool p_active) {
+	ERR_FAIL_COND_MSG(agent == nullptr, "LimboParallelState is not initialized.");
+
+	if (active == p_active) {
+		return;
+	}
+
+	active = p_active;
+
+	if (active) {
+		_enter();
+	} else {
+		_exit();
+	}
+}
+
+void LimboParallelState::_enter() {
+	set_process(update_mode == UpdateMode::IDLE);
+	set_physics_process(update_mode == UpdateMode::PHYSICS);
+
+	LimboState::_enter();
+
+	// Enter child states here
+	for (int i = 0; i < get_child_count(); i++) {
+		LimboState *c = Object::cast_to<LimboState>(get_child(i));
+		if (unlikely(c == nullptr)) {
+			ERR_PRINT(vformat("LimboParallelState: Child at index %d is not a LimboState.", i));
+		} else {
+			c->_enter();
+		}
+	}
+}
+
+void LimboParallelState::_exit() {
+	set_process(false);
+	set_physics_process(false);
+
+	// Exit child states here
+	for (int i = 0; i < get_child_count(); i++) {
+		LimboState *c = Object::cast_to<LimboState>(get_child(i));
+		if (unlikely(c == nullptr)) {
+			ERR_PRINT(vformat("LimboParallelState: Child at index %d is not a LimboState.", i));
+		} else {
+			c->_exit();
+		}
+	}
+
+	LimboState::_exit();
+}
+
+void LimboParallelState::_update(double p_delta) {
+	if (active) {
+		LimboState::_update(p_delta);
+
+		// Update child states here
+		for (int i = 0; i < get_child_count(); i++) {
+			LimboState *c = Object::cast_to<LimboState>(get_child(i));
+			if (unlikely(c == nullptr)) {
+				ERR_PRINT(vformat("LimboParallelState: Child at index %d is not a LimboState.", i));
+			} else {
+				c->_update(p_delta);
+			}
+		}
+	}
+}
+
+void LimboParallelState::update(double p_delta) {
+	updating = true;
+	_update(p_delta);
+	updating = false;
+}
+
+LimboState *LimboParallelState::get_leaf_state() const {
+	return const_cast<LimboParallelState *>(this);
+}
+
+
+bool LimboParallelState::_dispatch(const StringName &p_event, const Variant &p_cargo) {
+	ERR_FAIL_COND_V(p_event == StringName(), false);
+
+	bool event_consumed = false;
+
+	// Dispatch event to children
+	for (int i = 0; i < get_child_count(); i++) {
+		LimboState *c = Object::cast_to<LimboState>(get_child(i));
+		if (unlikely(c == nullptr)) {
+			ERR_PRINT(vformat("LimboParallelState: Child at index %d is not a LimboState.", i));
+		} else {
+			event_consumed = c->_dispatch(p_event, p_cargo) || event_consumed;
+		}
+	}
+
+	if (!event_consumed) {
+		event_consumed = LimboState::_dispatch(p_event, p_cargo);
+	}
+
+	return event_consumed;
+}
+
+void LimboParallelState::initialize(Node *p_agent, const Ref<Blackboard> &p_parent_scope) {
+	ERR_FAIL_COND(p_agent == nullptr);
+	ERR_FAIL_COND_MSG(!is_root(), "LimboParallelState: initialize() must be called on the root HSM.");
+
+	_initialize(p_agent, p_parent_scope);
+}
+
+void LimboParallelState::_initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard) {
+	ERR_FAIL_COND(p_agent == nullptr);
+	ERR_FAIL_COND_MSG(agent != nullptr, "LimboAI: ParallelState already initialized.");
+
+	LimboState::_initialize(p_agent, p_blackboard);
+
+	for (int i = 0; i < get_child_count(); i++) {
+		LimboState *c = Object::cast_to<LimboState>(get_child(i));
+		if (unlikely(c == nullptr)) {
+			ERR_PRINT(vformat("LimboParallelState: Child at index %d is not a LimboState.", i));
+		} else {
+			c->_initialize(agent, blackboard);
+		}
+	}
+}
+
+void LimboParallelState::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == LW_NAME(update_mode) && !is_root()) {
+		// Hide update_mode for non-root.
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
+void LimboParallelState::_exit_if_not_inside_tree() {
+	if (is_active() && !is_inside_tree()) {
+		_exit();
+	}
+}
+
+void LimboParallelState::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (was_active && is_root()) {
+				// Re-activate the root HSM if it was previously active.
+				// Typically, this happens when the node is re-entered scene repeatedly (such as with object pooling).
+				set_active(true);
+			}
+		} break;
+		case NOTIFICATION_READY: {
+			set_process(active && update_mode == UpdateMode::IDLE);
+			set_physics_process(active && update_mode == UpdateMode::PHYSICS);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			if (is_root()) {
+				// Exit the state machine if the root HSM is no longer in the scene tree (except when being reparented).
+				// This ensures that resources and signal connections are released if active.
+				was_active = is_active();
+				if (is_active()) {
+					// Check if the HSM node is being deleted.
+					bool is_being_deleted = false;
+					Node *node = this;
+					while (node) {
+						if (node->is_queued_for_deletion()) {
+							is_being_deleted = true;
+							break;
+						}
+						node = node->get_parent();
+					}
+
+					if (is_being_deleted) {
+						// Exit the state machine immediately if the HSM is being deleted.
+						_exit();
+					} else {
+						// Use deferred mode to prevent exiting during Node re-parenting.
+						// This allows the HSM to remain active when it (or one of its parents) is reparented.
+						callable_mp(this, &LimboParallelState::_exit_if_not_inside_tree).call_deferred();
+					}
+				}
+			}
+		} break;
+		case NOTIFICATION_PROCESS: {
+			update(get_process_delta_time());
+		} break;
+		case NOTIFICATION_PHYSICS_PROCESS: {
+			update(get_physics_process_delta_time());
+		} break;
+	}
+}
+
+void LimboParallelState::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_update_mode", "mode"), &LimboParallelState::set_update_mode);
+	ClassDB::bind_method(D_METHOD("get_update_mode"), &LimboParallelState::get_update_mode);
+
+	ClassDB::bind_method(D_METHOD("get_leaf_state"), &LimboParallelState::get_leaf_state);
+	ClassDB::bind_method(D_METHOD("set_active", "active"), &LimboParallelState::set_active);
+	ClassDB::bind_method(D_METHOD("update", "delta"), &LimboParallelState::update);
+	ClassDB::bind_method(D_METHOD("initialize", "agent", "parent_scope"), &LimboParallelState::initialize, Variant());
+
+	BIND_ENUM_CONSTANT(IDLE);
+	BIND_ENUM_CONSTANT(PHYSICS);
+	BIND_ENUM_CONSTANT(MANUAL);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Idle, Physics, Manual"), "set_update_mode", "get_update_mode");
+}
+
+LimboParallelState::LimboParallelState() {
+	update_mode = UpdateMode::PHYSICS;
+}

--- a/hsm/limbo_parallel_state.h
+++ b/hsm/limbo_parallel_state.h
@@ -1,0 +1,62 @@
+/**
+ * limbo_hsm.h
+ * =============================================================================
+ * Copyright (c) 2023-present Serhii Snitsaruk and the LimboAI contributors.
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ * =============================================================================
+ */
+
+#ifndef LIMBO_PARALLEL_STATE_H
+#define LIMBO_PARALLEL_STATE_H
+
+#include "limbo_state.h"
+
+class LimboParallelState : public LimboState {
+	GDCLASS(LimboParallelState, LimboState);
+
+public:
+	enum UpdateMode : unsigned int {
+		IDLE, // automatically call update() during NOTIFICATION_PROCESS
+		PHYSICS, // automatically call update() during NOTIFICATION_PHYSICS
+		MANUAL, // manually update state machine: user must call update(delta)
+	};
+
+private:
+	UpdateMode update_mode;
+	bool updating = false;
+	bool was_active = false;
+
+	void _exit_if_not_inside_tree();
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+	void _validate_property(PropertyInfo &p_property) const;
+
+	virtual void _initialize(Node *p_agent, const Ref<Blackboard> &p_blackboard) override;
+	virtual bool _dispatch(const StringName &p_event, const Variant &p_cargo = Variant()) override;
+
+	virtual void _enter() override;
+	virtual void _exit() override;
+	virtual void _update(double p_delta) override;
+
+public:
+	void set_update_mode(UpdateMode p_mode) { update_mode = p_mode; }
+	UpdateMode get_update_mode() const { return update_mode; }
+
+	void set_active(bool p_active);
+
+	LimboState *get_leaf_state() const;
+
+	virtual void initialize(Node *p_agent, const Ref<Blackboard> &p_parent_scope = nullptr);
+
+	void update(double p_delta);
+
+	LimboParallelState();
+};
+
+#endif // LIMBO_PARALLEL_STATE_H

--- a/hsm/limbo_state.h
+++ b/hsm/limbo_state.h
@@ -29,6 +29,7 @@
 #endif // LIMBOAI_GDEXTENSION
 
 class LimboHSM;
+class LimboParallelState;
 
 class LimboState : public Node {
 	GDCLASS(LimboState, Node);
@@ -46,6 +47,7 @@ private:
 
 protected:
 	friend LimboHSM;
+	friend LimboParallelState;
 
 	static void _bind_methods();
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -105,6 +105,7 @@
 #include "editor/mode_switch_button.h"
 #include "editor/tree_search.h"
 #include "hsm/limbo_hsm.h"
+#include "hsm/limbo_parallel_state.h"
 #include "hsm/limbo_state.h"
 #include "util/limbo_string_names.h"
 #include "util/limbo_task_db.h"
@@ -147,6 +148,7 @@ void initialize_limboai_module(ModuleInitializationLevel p_level) {
 
 		GDREGISTER_CLASS(LimboState);
 		GDREGISTER_CLASS(LimboHSM);
+		GDREGISTER_CLASS(LimboParallelState);
 
 		GDREGISTER_ABSTRACT_CLASS(BT);
 		GDREGISTER_ABSTRACT_CLASS(BTTask);


### PR DESCRIPTION
We discussed a `LimboParallelState` approach on Discord that would implement https://github.com/limbonaut/limboai/issues/129

Here is a proof of concept, looking for suggestions and feedback.

- The repetition of the loop code over children feels somewhat inelegant.
- I'm not sure about the event consuming behaviour, right now if one child state consumes then the ParallelState itself will not get a dispatch, which seemed sensible.
- There's no solution to the get_leaf_node problem yet, we just return the parallel state itself. (We talked about deprecating that and replacing with a get_leaf_nodes func.)
- There are no tests.
- The parallel state does not have a custom icon.