### PR TITLE
Fix crash in Godot 4.6 when trying to open behavior tree in the editor

### DIFF
--- a/bt/behavior_tree.cpp
+++ b/bt/behavior_tree.cpp
@@ -50,6 +50,15 @@ void BehaviorTree::set_blackboard_plan(const Ref<BlackboardPlan> &p_plan) {
 	_plan_changed();
 }
 
+Ref<BlackboardPlan> BehaviorTree::get_blackboard_plan() const {
+	if (blackboard_plan.is_null()) {
+		// Ensure we always return a valid plan to prevent null pointer dereferences
+		const_cast<BehaviorTree *>(this)->blackboard_plan = Ref<BlackboardPlan>(memnew(BlackboardPlan));
+	}
+
+	return blackboard_plan;
+}
+
 void BehaviorTree::set_root_task(const Ref<BTTask> &p_value) {
 #ifdef TOOLS_ENABLED
 	_unset_editor_behavior_tree_hint();

--- a/bt/behavior_tree.h
+++ b/bt/behavior_tree.h
@@ -56,7 +56,7 @@ public:
 	String get_description() const { return description; }
 
 	void set_blackboard_plan(const Ref<BlackboardPlan> &p_plan);
-	Ref<BlackboardPlan> get_blackboard_plan() const { return blackboard_plan; }
+	Ref<BlackboardPlan> get_blackboard_plan() const;
 
 	void set_root_task(const Ref<BTTask> &p_value);
 	Ref<BTTask> get_root_task() const { return root_task; }


### PR DESCRIPTION
Fixes https://github.com/limbonaut/limboai/issues/406

Not sure what changed in Godot 4.6, but it appears as thought the `blackboard_plan` can be `null` now. Lazy instantiation not working as expected?

---

**NOTE:** This fixes the crash for me, but now when I open a behavior tree I get this warning:

```
WARNING: core/object/class_db.cpp:2316 - Instantiated BlackboardPlan used as default value for BehaviorTree's "blackboard_plan" property.
```

It comes from here:

https://github.com/godotengine/godot/blob/1549d51865109a27216f2409a35f2c6dab7bb4d1/core/object/class_db.cpp#L2307-L2318

```cpp
#ifdef DEBUG_ENABLED
	// Some properties may have an instantiated Object as default value,
	// (like Path2D's `curve` used to have), but that's not a good practice.
	// Instead, those properties should use PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT
	// to be auto-instantiated when created in the editor with the following method:
	// EditorNode::get_editor_data().instantiate_object_properties(obj);
	if (var.get_type() == Variant::OBJECT) {
		Object *obj = var.get_validated_object();
		if (obj) {
			WARN_PRINT(vformat("Instantiated %s used as default value for %s's \"%s\" property.", obj->get_class(), p_class, p_property));
		}
	}
#endif // DEBUG_ENABLED
```

But `PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT` is being set here:

https://github.com/limbonaut/limboai/blob/1190119542717d30b1903ac87dab8838a1024b17/bt/behavior_tree.cpp#L133

~~I do wonder if this is something that will be fixed by `godot-cpp` `4.6-stable` once that is out? They just put out 4.6-rc1 today~~ No, tried this against `godot-cpp` `master` and still get the warning...