### PR TITLE
Debugger: Blackboard runtime inspection

### DIFF
--- a/blackboard/blackboard.cpp
+++ b/blackboard/blackboard.cpp
@@ -76,9 +76,10 @@ void Blackboard::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 
 	// Collect scopes: [0]=this (local), [1]=parent, [2]=grandparent, ...
+	static constexpr int MAX_SCOPE_DEPTH = 16;
 	Vector<const Blackboard *> scopes;
 	const Blackboard *bb = this;
-	while (bb && scopes.size() < 16) {
+	while (bb && scopes.size() < MAX_SCOPE_DEPTH) {
 		scopes.push_back(bb);
 		bb = bb->parent.ptr();
 	}

--- a/blackboard/blackboard.cpp
+++ b/blackboard/blackboard.cpp
@@ -66,13 +66,15 @@ void Blackboard::_get_property_list(List<PropertyInfo> *p_list) const {
 	// Emit in reverse order: top-most scope first, local scope last.
 	for (int i = scopes.size() - 1; i >= 0; i--) {
 		String scope_prefix = "scope_" + itos(i) + "/";
-		String group_name = "Scope " + itos(i);
+		String group_name;
 		if (i == 0) {
-			group_name += " (local)";
+			group_name = "Local Scope";
+		} else if (scopes.size() == 2) {
+			group_name = "Parent Scope";
 		} else {
-			group_name += " (parent)";
+			group_name = "Parent Scope " + itos(i);
 		}
-		p_list->push_back(PropertyInfo(Variant::NIL, group_name, PROPERTY_HINT_NONE, scope_prefix, PROPERTY_USAGE_GROUP));
+		p_list->push_back(PropertyInfo(Variant::NIL, group_name, PROPERTY_HINT_NONE, scope_prefix, PROPERTY_USAGE_GROUP | PROPERTY_USAGE_EDITOR));
 
 		// Collect and sort variable names.
 		Vector<String> sorted_names;

--- a/blackboard/blackboard.cpp
+++ b/blackboard/blackboard.cpp
@@ -58,7 +58,7 @@ void Blackboard::_get_property_list(List<PropertyInfo> *p_list) const {
 	// Collect scopes: [0]=this (local), [1]=parent, [2]=grandparent, ...
 	Vector<const Blackboard *> scopes;
 	const Blackboard *bb = this;
-	while (bb) {
+	while (bb && scopes.size() < 16) {
 		scopes.push_back(bb);
 		bb = bb->parent.ptr();
 	}

--- a/blackboard/blackboard.h
+++ b/blackboard/blackboard.h
@@ -40,6 +40,10 @@ private:
 protected:
 	static void _bind_methods();
 
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 #ifdef LIMBOAI_GDEXTENSION
 	String _to_string() const { return "<" + get_class() + "#" + itos(get_instance_id()) + ">"; }
 #endif

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -282,7 +282,7 @@ void BTPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "agent_node"), "set_agent_node", "get_agent_node");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Idle,Physics,Manual"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "get_active");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", PROPERTY_USAGE_RUNTIME), "set_blackboard", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "set_blackboard", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitor_performance"), "set_monitor_performance", "get_monitor_performance");
 

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -282,7 +282,7 @@ void BTPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "agent_node"), "set_agent_node", "get_agent_node");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Idle,Physics,Manual"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "get_active");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "set_blackboard", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT()), "set_blackboard", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitor_performance"), "set_monitor_performance", "get_monitor_performance");
 

--- a/bt/bt_player.cpp
+++ b/bt/bt_player.cpp
@@ -11,6 +11,7 @@
 
 #include "bt_player.h"
 
+#include "../compat/limbo_compat.h"
 #include "../compat/node.h"
 #include "../compat/resource.h"
 #include "../util/limbo_string_names.h"
@@ -281,7 +282,7 @@ void BTPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "agent_node"), "set_agent_node", "get_agent_node");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Idle,Physics,Manual"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "get_active");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", 0), "set_blackboard", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_NONE, "Blackboard", PROPERTY_USAGE_RUNTIME), "set_blackboard", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitor_performance"), "set_monitor_performance", "get_monitor_performance");
 

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -11,6 +11,7 @@
 
 #include "bt_task.h"
 
+#include "../../compat/limbo_compat.h"
 #include "../../compat/object.h"
 #include "../../compat/print.h"
 #include "../../util/limbo_string_names.h"
@@ -426,7 +427,7 @@ void BTTask::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom_name"), "set_custom_name", "get_custom_name");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_agent", "get_agent");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_NODE_TYPE, "Node", PROPERTY_USAGE_NONE), "", "get_scene_root");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_NONE), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_RUNTIME), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_children", "_get_children");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_status");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "elapsed_time", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_elapsed_time");

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -427,7 +427,7 @@ void BTTask::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom_name"), "set_custom_name", "get_custom_name");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_agent", "get_agent");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_NODE_TYPE, "Node", PROPERTY_USAGE_NONE), "", "get_scene_root");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT()), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_children", "_get_children");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_status");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "elapsed_time", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_elapsed_time");

--- a/bt/tasks/bt_task.cpp
+++ b/bt/tasks/bt_task.cpp
@@ -427,7 +427,7 @@ void BTTask::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom_name"), "set_custom_name", "get_custom_name");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_agent", "get_agent");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_NODE_TYPE, "Node", PROPERTY_USAGE_NONE), "", "get_scene_root");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_RUNTIME), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_children", "_get_children");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_status");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "elapsed_time", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_elapsed_time");

--- a/compat/limbo_compat.h
+++ b/compat/limbo_compat.h
@@ -52,4 +52,7 @@
 
 #endif // ! LIMBOAI_GDEXTENSION
 
+// Property visible to the remote debugger at runtime, but hidden in the editor.
+#define PROPERTY_USAGE_RUNTIME (Engine::get_singleton()->is_editor_hint() ? PROPERTY_USAGE_NONE : PROPERTY_USAGE_EDITOR)
+
 #endif // LIMBO_COMPAT_H

--- a/compat/limbo_compat.h
+++ b/compat/limbo_compat.h
@@ -53,6 +53,6 @@
 #endif // ! LIMBOAI_GDEXTENSION
 
 // Property visible to the remote debugger at runtime, but hidden in the editor.
-#define PROPERTY_USAGE_RUNTIME (Engine::get_singleton()->is_editor_hint() ? PROPERTY_USAGE_NONE : PROPERTY_USAGE_EDITOR)
+#define PROPERTY_USAGE_EDITOR_INSPECT (Engine::get_singleton()->is_editor_hint() ? PROPERTY_USAGE_NONE : PROPERTY_USAGE_EDITOR)
 
 #endif // LIMBO_COMPAT_H

--- a/compat/limbo_compat.h
+++ b/compat/limbo_compat.h
@@ -53,6 +53,6 @@
 #endif // ! LIMBOAI_GDEXTENSION
 
 // Property visible to the remote debugger at runtime, but hidden in the editor.
-#define PROPERTY_USAGE_EDITOR_INSPECT (Engine::get_singleton()->is_editor_hint() ? PROPERTY_USAGE_NONE : PROPERTY_USAGE_EDITOR)
+#define PROPERTY_USAGE_EDITOR_INSPECT() (Engine::get_singleton()->is_editor_hint() ? PROPERTY_USAGE_NONE : PROPERTY_USAGE_EDITOR)
 
 #endif // LIMBO_COMPAT_H

--- a/doc/source/behavior-trees/create-tree.rst
+++ b/doc/source/behavior-trees/create-tree.rst
@@ -22,3 +22,11 @@ Debugging Behavior Trees
 In Godot Engine, follow to "Bottom Panel > Debugger > LimboAI" tab. With the LimboAI debugger,
 you can inspect any currently active behavior tree within the running project. The debugger can be detached
 from the main editor window, which can be particularly useful if you have a HiDPI or a secondary display.
+
+Inspecting task properties and blackboard
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you click on a task in the LimboAI debugger, its properties are shown in the remote Inspector panel,
+including the :ref:`Blackboard<class_Blackboard>` reference. Click the :ref:`Blackboard<class_Blackboard>`
+to open it and view all variables across the full scope chain, grouped by scope.
+You can also edit variable values live, which can be useful for testing and debugging your game's AI.

--- a/doc/source/behavior-trees/using-blackboard.rst
+++ b/doc/source/behavior-trees/using-blackboard.rst
@@ -248,3 +248,13 @@ We assign that scope to each agent in a group through code:
 In conclusion, the :ref:`Blackboard<class_Blackboard>` scope chain not only
 prevents naming conflicts that can occur between state machines, behavior trees, and sub-trees,
 but it can also be used to share data between several agents.
+
+Debugging blackboard variables
+------------------------------
+
+When debugging a running project, you can inspect :ref:`Blackboard<class_Blackboard>` variables
+in the remote Inspector. Click on a task in the LimboAI debugger to view its properties,
+then click the :ref:`Blackboard<class_Blackboard>` reference to see all variables across the full
+scope chain, grouped by scope. Variables can be edited live to aid in debugging.
+For state machines, select a :ref:`LimboState<class_LimboState>` node in the Remote Scene Tree
+to access its :ref:`Blackboard<class_Blackboard>` in the same way.

--- a/doc_classes/BTPlayer.xml
+++ b/doc_classes/BTPlayer.xml
@@ -57,6 +57,7 @@
 		</member>
 		<member name="blackboard" type="Blackboard" setter="set_blackboard" getter="get_blackboard">
 			Holds data shared by the behavior tree tasks. See [Blackboard].
+			[b]Debugging:[/b] When debugging a running project, this property is visible in the remote Inspector. Click the [Blackboard] reference to inspect and edit variables across the full scope chain.
 		</member>
 		<member name="blackboard_plan" type="BlackboardPlan" setter="set_blackboard_plan" getter="get_blackboard_plan">
 			Stores and manages variables that will be used in constructing new [Blackboard] instances.

--- a/doc_classes/BTTask.xml
+++ b/doc_classes/BTTask.xml
@@ -217,6 +217,7 @@
 		<member name="blackboard" type="Blackboard" setter="" getter="get_blackboard">
 			Provides access to the [Blackboard]. Blackboard is used to share data among tasks of the associated [BehaviorTree].
 			See [Blackboard] for additional info.
+			[b]Debugging:[/b] When a task is selected in the LimboAI debugger, its properties are shown in the remote Inspector. Click the [Blackboard] reference to inspect and edit variables across the full scope chain.
 		</member>
 		<member name="custom_name" type="String" setter="set_custom_name" getter="get_custom_name" default="&quot;&quot;">
 			User-provided name for the task. If not empty, it is used by the editor to represent the task. See [method get_task_name].

--- a/doc_classes/Blackboard.xml
+++ b/doc_classes/Blackboard.xml
@@ -7,6 +7,7 @@
 		Blackboard is where data is stored and shared between states in the [LimboHSM] system and tasks in a [BehaviorTree]. Each state and task in the [BehaviorTree] can access this Blackboard, allowing them to read and write data. This makes it easy to share information between different actions and behaviors.
 		Blackboard can also act as a parent scope for another Blackboard. If a specific variable is not found in the active scope, it looks in the parent Blackboard to find it. A parent Blackboard can itself have its own parent scope, forming what we call a "blackboard scope chain." Importantly, there is no limit to how many Blackboards can be in this chain, and the Blackboard doesn't modify values in the parent scopes.
 		New scopes can be created using the [BTNewScope] and [BTSubtree] decorators. Additionally, a new scope is automatically created for any [LimboState] that has defined non-empty Blackboard data or for any root-level [LimboHSM] node.
+		[b]Debugging:[/b] When debugging a running project, a Blackboard can be viewed in the remote Inspector, displaying all variables across the full scope chain grouped by scope. Variables can also be edited live.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc_classes/LimboState.xml
+++ b/doc_classes/LimboState.xml
@@ -140,6 +140,7 @@
 		</member>
 		<member name="blackboard" type="Blackboard" setter="" getter="get_blackboard">
 			A key/value data store shared by states within the state machine to which this state belongs.
+			[b]Debugging:[/b] When debugging a running project, select a [LimboState] node in the Remote Scene Tree to see its properties in the remote Inspector. Click the [Blackboard] reference to inspect and edit variables across the full scope chain.
 		</member>
 		<member name="blackboard_plan" type="BlackboardPlan" setter="set_blackboard_plan" getter="get_blackboard_plan">
 			Stores and manages variables that will be used in constructing new [Blackboard] instances.

--- a/editor/debugger/behavior_tree_view.cpp
+++ b/editor/debugger/behavior_tree_view.cpp
@@ -232,6 +232,14 @@ void BehaviorTreeView::_update_tree(const Ref<BehaviorTreeData> &p_data) {
 	}
 }
 
+uint64_t BehaviorTreeView::get_selected_task_id() const {
+	TreeItem *selected = tree->get_selected();
+	if (selected) {
+		return item_get_task_id(selected);
+	}
+	return 0;
+}
+
 void BehaviorTreeView::clear() {
 	tree->clear();
 	collapsed_ids.clear();

--- a/editor/debugger/behavior_tree_view.h
+++ b/editor/debugger/behavior_tree_view.h
@@ -80,6 +80,8 @@ public:
 	void clear();
 	void update_tree(const Ref<BehaviorTreeData> &p_data);
 
+	uint64_t get_selected_task_id() const;
+
 	void set_update_interval_msec(int p_milliseconds) { update_interval_msec = p_milliseconds; }
 	int get_update_interval_msec() const { return update_interval_msec; }
 

--- a/editor/debugger/limbo_debugger_plugin.cpp
+++ b/editor/debugger/limbo_debugger_plugin.cpp
@@ -152,6 +152,18 @@ void LimboDebuggerTab::_window_visibility_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
 }
 
+void LimboDebuggerTab::_on_task_selected(const String &p_type_name, const String &p_script_path) {
+	uint64_t task_id = bt_view->get_selected_task_id();
+	if (task_id != 0) {
+		Array ids;
+		ids.push_back(task_id);
+		Array msg;
+		msg.push_back(ids);
+		msg.push_back(true); // Request remote object inspection.
+		session->send_message("scene:inspect_objects", msg);
+	}
+}
+
 void LimboDebuggerTab::_resource_header_pressed() {
 	String bt_path = resource_header->get_text();
 	if (bt_path.is_empty()) {
@@ -173,6 +185,7 @@ void LimboDebuggerTab::_notification(int p_what) {
 			resource_header->connect(LW_NAME(pressed), callable_mp(this, &LimboDebuggerTab::_resource_header_pressed));
 			filter_players->connect(LW_NAME(text_changed), callable_mp(this, &LimboDebuggerTab::_filter_changed));
 			bt_instance_list->connect(LW_NAME(item_selected), callable_mp(this, &LimboDebuggerTab::_bt_instance_selected));
+			bt_view->connect(LW_NAME(task_selected), callable_mp(this, &LimboDebuggerTab::_on_task_selected));
 			update_interval->connect("value_changed", callable_mp(bt_view, &BehaviorTreeView::set_update_interval_msec));
 
 			Ref<ConfigFile> cf;

--- a/editor/debugger/limbo_debugger_plugin.h
+++ b/editor/debugger/limbo_debugger_plugin.h
@@ -82,6 +82,7 @@ private:
 	void _filter_changed(String p_text);
 	void _window_visibility_changed(bool p_visible);
 	void _resource_header_pressed();
+	void _on_task_selected(const String &p_type_name, const String &p_script_path);
 
 protected:
 	static void _bind_methods();

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -254,8 +254,8 @@ void LimboState::_bind_methods() {
 	GDVIRTUAL_BIND(_update, "delta");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "EVENT_FINISHED", PROPERTY_HINT_NONE, "", 0), "", "event_finished");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_EDITOR_INSPECT), "set_agent", "get_agent");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_EDITOR_INSPECT()), "set_agent", "get_agent");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT()), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 
 	ADD_SIGNAL(MethodInfo("setup"));

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -11,6 +11,8 @@
 
 #include "limbo_state.h"
 
+#include "../compat/limbo_compat.h"
+
 #ifdef LIMBOAI_MODULE
 #include "core/config/engine.h"
 #endif // LIMBOAI_MODULE
@@ -252,8 +254,8 @@ void LimboState::_bind_methods() {
 	GDVIRTUAL_BIND(_update, "delta");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "EVENT_FINISHED", PROPERTY_HINT_NONE, "", 0), "", "event_finished");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0), "set_agent", "get_agent");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", 0), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_RUNTIME), "set_agent", "get_agent");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_RUNTIME), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 
 	ADD_SIGNAL(MethodInfo("setup"));

--- a/hsm/limbo_state.cpp
+++ b/hsm/limbo_state.cpp
@@ -254,8 +254,8 @@ void LimboState::_bind_methods() {
 	GDVIRTUAL_BIND(_update, "delta");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "EVENT_FINISHED", PROPERTY_HINT_NONE, "", 0), "", "event_finished");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_RUNTIME), "set_agent", "get_agent");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_RUNTIME), "", "get_blackboard");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "agent", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_EDITOR_INSPECT), "set_agent", "get_agent");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard", PROPERTY_HINT_RESOURCE_TYPE, "Blackboard", PROPERTY_USAGE_EDITOR_INSPECT), "", "get_blackboard");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "blackboard_plan", PROPERTY_HINT_RESOURCE_TYPE, "BlackboardPlan", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE), "set_blackboard_plan", "get_blackboard_plan");
 
 	ADD_SIGNAL(MethodInfo("setup"));


### PR DESCRIPTION
This PR makes `Blackboard` expose its runtime state (including parent scope chain) to Inspector as virtual properties. When the remote inspector inspects a Blackboard instance, it sees all variables from all scopes with proper type/hint metadata. Also, variable values can be edited remotely just like with remote scene tree.

- Closes #363

<img width="305" height="582" alt="image" src="https://github.com/user-attachments/assets/b480479c-7a10-4224-a0a5-3ee0bf019802" />

## Demonstration

https://github.com/user-attachments/assets/ff0c8e12-6824-4991-bbee-1664c8924055

