### PR TITLE
Clicking online documentation button leads to 404 page

### DIFF
--- a/limboai_version.py
+++ b/limboai_version.py
@@ -4,7 +4,7 @@ major = 1
 minor = 7
 patch = 0
 status = ""
-doc_branch = "1.7.0"
+doc_branch = "v1.7.0"
 
 
 def get_godot_cpp_ref():


### PR DESCRIPTION
Clicking the Online Documentation button in the LimboAI Misc dropdown generates an invalid url because the "v" is missing in doc_branch

Currently the browser tries to open https://limboai.readthedocs.io/en/1.7.0/, which shows a 404 page because it is missing a v before the 1.7.0. 
The url should be https://limboai.readthedocs.io/en/v1.7.0/