### PR TITLE
Add support for indexed proeprty access

### DIFF
--- a/blackboard/bb_variable.cpp
+++ b/blackboard/bb_variable.cpp
@@ -30,10 +30,10 @@ void BBVariable::set_value(const Variant &p_value) {
 		ERR_FAIL_COND_MSG(!obj, "Blackboard: Failed to get bound object.");
 #ifdef LIMBOAI_MODULE
 		bool r_valid;
-		obj->set(data->bound_property, p_value, &r_valid);
-		ERR_FAIL_COND_MSG(!r_valid, vformat("Blackboard: Failed to set bound property `%s` on %s", data->bound_property, obj));
+		obj->set_indexed(data->bound_nodepath, p_value, &r_valid);
+		ERR_FAIL_COND_MSG(!r_valid, vformat("Blackboard: Failed to set bound property `%s` on %s", data->bound_nodepath, obj));
 #elif LIMBOAI_GDEXTENSION
-		obj->set(data->bound_property, p_value);
+		obj->set_indexed(data->bound_nodepath, p_value);
 #endif
 	}
 }
@@ -44,10 +44,10 @@ Variant BBVariable::get_value() const {
 		ERR_FAIL_COND_V_MSG(!obj, data->value, "Blackboard: Failed to get bound object.");
 #ifdef LIMBOAI_MODULE
 		bool r_valid;
-		Variant ret = obj->get(data->bound_property, &r_valid);
-		ERR_FAIL_COND_V_MSG(!r_valid, data->value, vformat("Blackboard: Failed to get bound property `%s` on %s", data->bound_property, obj));
+		Variant ret = obj->get_indexed(data->bound_nodepath, &r_valid);
+		ERR_FAIL_COND_V_MSG(!r_valid, data->value, vformat("Blackboard: Failed to get bound property `%s` on %s", data->bound_nodepath, obj));
 #elif LIMBOAI_GDEXTENSION
-		Variant ret = obj->get(data->bound_property);
+		Variant ret = obj->get_indexed(data->bound_nodepath);
 #endif
 		return ret;
 	}
@@ -120,11 +120,13 @@ void BBVariable::bind(Object *p_object, const StringName &p_property) {
 	ERR_FAIL_COND_MSG(!OBJECT_HAS_PROPERTY(p_object, p_property), vformat("Blackboard: Binding failed - %s has no property `%s`.", p_object, p_property));
 	data->bound_object = p_object->get_instance_id();
 	data->bound_property = p_property;
+	data->bound_nodepath = NodePath{ p_property };
 }
 
 void BBVariable::unbind() {
 	data->bound_object = 0;
 	data->bound_property = StringName();
+	data->bound_nodepath = NodePath();
 }
 
 bool BBVariable::operator==(const BBVariable &p_var) const {

--- a/blackboard/bb_variable.h
+++ b/blackboard/bb_variable.h
@@ -38,6 +38,7 @@ private:
 		NodePath binding_path;
 		uint64_t bound_object = 0;
 		StringName bound_property;
+		NodePath bound_nodepath;
 	};
 
 	Data *data = nullptr;

--- a/blackboard/blackboard_plan.cpp
+++ b/blackboard/blackboard_plan.cpp
@@ -567,13 +567,12 @@ void BlackboardPlan::populate_blackboard(const Ref<Blackboard> &p_blackboard, bo
 				binding_path = get_base_plan()->property_bindings[p.first];
 				binding_root = p_prefetch_root_for_base_plan;
 			}
-			ERR_CONTINUE_MSG(binding_path.get_subname_count() != 1, vformat("BlackboardPlan: Can't bind variable %s using property path that contains multiple sub-names: %s", LimboUtility::get_singleton()->decorate_var(p.first), binding_path));
 			NodePath node_path{ binding_path.get_concatenated_names() };
-			StringName prop_name = binding_path.get_subname(0);
+			StringName property_path{ binding_path.get_concatenated_subnames() };
 			// TODO: Implement binding for base plan as well.
 			Node *n = binding_root->get_node_or_null(node_path);
 			ERR_CONTINUE_MSG(n == nullptr, vformat("BlackboardPlan: Binding failed for variable %s using property path: %s", LimboUtility::get_singleton()->decorate_var(p.first), binding_path));
-			var.bind(n, prop_name);
+			var.bind(n, property_path);
 		}
 	}
 }

--- a/bt/tasks/scene/bt_check_agent_property.cpp
+++ b/bt/tasks/scene/bt_check_agent_property.cpp
@@ -23,6 +23,7 @@
 
 void BTCheckAgentProperty::set_property(StringName p_prop) {
 	property = p_prop;
+	property_path = NodePath{ p_prop };
 	emit_changed();
 }
 
@@ -67,10 +68,10 @@ BT::Status BTCheckAgentProperty::_tick(double p_delta) {
 
 #ifdef LIMBOAI_MODULE
 	bool r_valid;
-	Variant left_value = get_agent()->get(property, &r_valid);
+	Variant left_value = get_agent()->get_indexed(property_path, &r_valid);
 	ERR_FAIL_COND_V_MSG(r_valid == false, FAILURE, vformat("BTCheckAgentProperty: Agent has no property named \"%s\"", property));
 #elif LIMBOAI_GDEXTENSION
-	Variant left_value = get_agent()->get(property);
+	Variant left_value = get_agent()->get_indexed(property_path);
 #endif
 
 	Variant right_value = value->get_value(get_scene_root(), get_blackboard());

--- a/bt/tasks/scene/bt_check_agent_property.h
+++ b/bt/tasks/scene/bt_check_agent_property.h
@@ -23,6 +23,7 @@ class BTCheckAgentProperty : public BTCondition {
 
 private:
 	StringName property;
+	NodePath property_path;
 	LimboUtility::CheckType check_type = LimboUtility::CheckType::CHECK_EQUAL;
 	Ref<BBVariant> value;
 
@@ -35,6 +36,7 @@ protected:
 public:
 	void set_property(StringName p_prop);
 	StringName get_property() const { return property; }
+	NodePath get_property_path() const { return property_path; }
 
 	void set_check_type(LimboUtility::CheckType p_check_type);
 	LimboUtility::CheckType get_check_type() const { return check_type; }

--- a/bt/tasks/scene/bt_set_agent_property.cpp
+++ b/bt/tasks/scene/bt_set_agent_property.cpp
@@ -23,6 +23,7 @@
 
 void BTSetAgentProperty::set_property(StringName p_prop) {
 	property = p_prop;
+	property_path = NodePath{ p_prop };
 	emit_changed();
 }
 
@@ -75,20 +76,20 @@ BT::Status BTSetAgentProperty::_tick(double p_delta) {
 		result = right_value;
 	} else {
 #ifdef LIMBOAI_MODULE
-		Variant left_value = get_agent()->get(property, &r_valid);
+		Variant left_value = get_agent()->get_indexed(property_path, &r_valid);
 		ERR_FAIL_COND_V_MSG(!r_valid, FAILURE, vformat("BTSetAgentProperty: Failed to get agent's \"%s\" property. Returning FAILURE.", property));
 #elif LIMBOAI_GDEXTENSION
-		Variant left_value = get_agent()->get(property);
+		Variant left_value = get_agent()->get_indexed(property_path);
 #endif
 		result = LimboUtility::get_singleton()->perform_operation(operation, left_value, right_value);
 		ERR_FAIL_COND_V_MSG(result == Variant(), FAILURE, "BTSetAgentProperty: Operation not valid. Returning FAILURE.");
 	}
 
 #ifdef LIMBOAI_MODULE
-	get_agent()->set(property, result, &r_valid);
+	get_agent()->set_indexed(property_path, result, &r_valid);
 	ERR_FAIL_COND_V_MSG(!r_valid, FAILURE, vformat("BTSetAgentProperty: Couldn't set property \"%s\" with value \"%s\"", property, result));
 #elif LIMBOAI_GDEXTENSION
-	get_agent()->set(property, result);
+	get_agent()->set_indexed(property_path, result);
 #endif
 	return SUCCESS;
 }

--- a/bt/tasks/scene/bt_set_agent_property.h
+++ b/bt/tasks/scene/bt_set_agent_property.h
@@ -23,6 +23,7 @@ class BTSetAgentProperty : public BTAction {
 
 private:
 	StringName property;
+	NodePath property_path;
 	Ref<BBVariant> value;
 	LimboUtility::Operation operation = LimboUtility::OPERATION_NONE;
 

--- a/compat/object.h
+++ b/compat/object.h
@@ -21,7 +21,12 @@
 
 _FORCE_INLINE_ bool OBJECT_HAS_PROPERTY(Object *p_obj, const StringName &p_prop) {
 	bool r_valid;
-	return Variant(p_obj).has_key(p_prop, r_valid);
+	if (p_prop.find(":") > -1) {
+		// Nested subnames cannot be checked
+		return true;
+	} else {
+		return Variant(p_obj).has_key(p_prop, r_valid);
+	}
 }
 
 #endif // LIMBOAI_MODULE
@@ -37,7 +42,12 @@ _FORCE_INLINE_ bool OBJECT_HAS_PROPERTY(Object *p_obj, const StringName &p_prop)
 #define GET_SCRIPT(m_obj) (m_obj->get_script())
 
 _FORCE_INLINE_ bool OBJECT_HAS_PROPERTY(Object *p_obj, const StringName &p_prop) {
-	return Variant(p_obj).has_key(p_prop);
+	if (p_prop.find(":") > -1) {
+		// Nested subnames cannot be checked
+		return true;
+	} else {
+		return Variant(p_obj).has_key(p_prop);
+	}
 }
 
 #endif // LIMBOAI_GDEXTENSION


### PR DESCRIPTION
This PR makes possible to bind properties with multiple subnames (in example `"rect:size:x"`) to bbtable properties. Also expands CheckAgentProperty and SetAgentProperty to suport multime subnames

https://github.com/user-attachments/assets/55bd3019-9fa4-4f06-bab8-2b15dacd6d31

